### PR TITLE
Fix production retry trigger update

### DIFF
--- a/scripts/__tests__/deploy-lead-intake.test.cjs
+++ b/scripts/__tests__/deploy-lead-intake.test.cjs
@@ -41,3 +41,9 @@ test('lead deployment package contains every runtime YDB module', () => {
   assert.match(deployScript, /lead-intake\/build\/\./);
   assert.match(deployScript, /cp -R/);
 });
+
+test('existing retry trigger is updated by resolved id', () => {
+  assert.match(deployScript, /TRIGGER_ID=.*serverless trigger get/);
+  assert.match(deployScript, /serverless trigger update timer[\s\\]+--id="\$\{TRIGGER_ID\}"/);
+  assert.doesNotMatch(deployScript, /serverless trigger update timer[\s\\]+--name=/);
+});

--- a/scripts/deploy-lead-intake.sh
+++ b/scripts/deploy-lead-intake.sh
@@ -139,8 +139,18 @@ yc serverless function version create \
 yc serverless function allow-unauthenticated-invoke "${FUNCTION_NAME}"
 
 if yc serverless trigger get --name="${TRIGGER_NAME}" >/dev/null 2>&1; then
+  TRIGGER_ID="$(yc serverless trigger get --name="${TRIGGER_NAME}" --format=json | node -e "
+const fs = require('fs');
+const data = JSON.parse(fs.readFileSync(0, 'utf8'));
+process.stdout.write(data.id || '');
+")"
+  if [[ -z "${TRIGGER_ID}" ]]; then
+    echo "deploy-lead-intake: failed to resolve trigger id for ${TRIGGER_NAME}" >&2
+    exit 1
+  fi
+
   yc serverless trigger update timer \
-    --name="${TRIGGER_NAME}" \
+    --id="${TRIGGER_ID}" \
     --new-cron-expression='* * * * ? *' \
     --new-payload='retry-telegram' \
     --new-invoke-function-name="${FUNCTION_NAME}" \


### PR DESCRIPTION
## Summary
- resolve the existing timer trigger ID before update
- use the ID required by the current Yandex Cloud CLI
- add a deploy-script regression test

## Verification
- bash -n scripts/deploy-lead-intake.sh
- npm run test:lead-import
- npm run lint:public