### PR TITLE
Force IPv4 for Telegram delivery

### DIFF
--- a/functions/lead-intake/src/telegram/__tests__/delivery.test.ts
+++ b/functions/lead-intake/src/telegram/__tests__/delivery.test.ts
@@ -1,9 +1,14 @@
 import assert from 'node:assert/strict';
+import { getDefaultResultOrder } from 'node:dns';
 import test from 'node:test';
 
 import { buildMessage, retryBatchSize, sendTelegram, telegramTimeoutMs } from '../delivery';
 
 const LEAD_ID = '1cc32f4f-8f06-4dc8-915f-92955c829523';
+
+test('Telegram networking prefers IPv4 for Yandex Cloud Functions', () => {
+  assert.equal(getDefaultResultOrder(), 'ipv4first');
+});
 
 test('message includes the stable lead id and selected attribution fields', () => {
   const message = buildMessage({

--- a/functions/lead-intake/src/telegram/delivery.ts
+++ b/functions/lead-intake/src/telegram/delivery.ts
@@ -1,3 +1,5 @@
+import { setDefaultResultOrder } from 'node:dns';
+
 import { TRACKED_UTM_PARAMS, sanitize } from '../lead-payload';
 
 import type { ClaimedLead, HandlerDependencies, JsonObject, LoggerLike, UtmKey } from '../types';
@@ -8,6 +10,9 @@ const TELEGRAM_LEASE_MS = 2 * 60 * 1000;
 const DEFAULT_RETRY_BATCH_SIZE = 5;
 const MAX_RETRY_BATCH_SIZE = 25;
 const DEFAULT_MAX_TELEGRAM_ATTEMPTS = 12;
+
+// Yandex Cloud Functions has public IPv4 egress only, while Telegram DNS returns IPv6 first.
+setDefaultResultOrder('ipv4first');
 
 const UTM_LABELS: Record<UtmKey, string> = {
   utm_source: 'source',


### PR DESCRIPTION
## Root cause
Yandex Cloud Functions provides public IPv4 egress, while api.telegram.org resolves IPv6 first. The production worker failed with UND_ERR_CONNECT_TIMEOUT.

## Fix
- prefer IPv4 DNS results in the lead function runtime
- add a regression test for resolver order

## Verification
- npm --prefix functions/lead-intake test
- npm run lint:public