### PR TITLE
Fix generated Yandex Maps configuration

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,6 @@
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-Content-Type-Options" content="nosniff">
-  <meta http-equiv="X-Frame-Options" content="SAMEORIGIN">
   <meta name="referrer" content="strict-origin-when-cross-origin">
   <title>Фитнес-клуб ZvenFit в Звенигороде — зал, пилатес, персональные тренировки</title>
   <meta name="description" content="Фитнес-клуб ZvenFit Звенигород: тренажерный зал 500м², пилатес на реформере, персональные тренировки. Рассрочка 0%, пробная тренировка 1000₽. ☎ +7 (925) 308-23-23">

--- a/public/js/maps-config.js
+++ b/public/js/maps-config.js
@@ -1,4 +1,4 @@
-/* global __ZVENFIT_MAPS_JSON__:readonly */
+/* eslint-disable no-undef */
 
 // Injected at build time (see scripts/build-static.cjs)
 window.ZVENFIT_MAPS = __ZVENFIT_MAPS_JSON__;

--- a/scripts/build-static.cjs
+++ b/scripts/build-static.cjs
@@ -74,6 +74,7 @@ const SITE_CSS_SOURCE = 'zvenfit.webflow.css';
 const SITE_CSS_MIN = 'zvenfit.webflow.min.css';
 const ASSETS_CDN_BASE = 'https://storage.yandexcloud.net/zvenfit/v2';
 const CDN_VENDOR_JS = ['webflow.js'];
+const MAPS_CONFIG_PLACEHOLDER = '__ZVENFIT_MAPS_JSON__';
 const CACHE_BUST_SCRIPTS = [
   'utm-attribution.js',
   'lead-form.js',
@@ -242,9 +243,15 @@ function writeMapsConfig(distDir, structuredDataConfig, mapsConfig) {
 
   const runtimeConfig = buildMapsRuntimeConfig(structuredDataConfig, mapsConfig);
   const template = fs.readFileSync(mapsConfigPathDist, 'utf8');
+  const placeholderCount = template.split(MAPS_CONFIG_PLACEHOLDER).length - 1;
+  if (placeholderCount !== 1) {
+    throw new Error(`build-static: maps config template must contain exactly one placeholder; found ${placeholderCount}`);
+  }
+
+  const output = template.replace(MAPS_CONFIG_PLACEHOLDER, JSON.stringify(runtimeConfig, null, 2));
   fs.writeFileSync(
     mapsConfigPathDist,
-    template.replace('__ZVENFIT_MAPS_JSON__', JSON.stringify(runtimeConfig, null, 2)),
+    output,
     'utf8',
   );
 }

--- a/scripts/check-build.cjs
+++ b/scripts/check-build.cjs
@@ -2,6 +2,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const vm = require('vm');
 
 const rootDir = path.join(__dirname, '..');
 const publicDir = path.join(rootDir, 'public');
@@ -30,6 +31,22 @@ if (fs.existsSync(path.join(distDir, 'js', 'webflow.js'))) {
   throw new Error('check-build: dist/js/webflow.js must be served from the assets CDN');
 }
 
+const mapsConfigPath = path.join(distDir, 'js', 'maps-config.js');
+if (!fs.existsSync(mapsConfigPath)) {
+  throw new Error('check-build: dist/js/maps-config.js is missing');
+}
+
+const mapsConfigSource = fs.readFileSync(mapsConfigPath, 'utf8');
+if (mapsConfigSource.includes('__ZVENFIT_MAPS_JSON__')) {
+  throw new Error('check-build: maps-config.js still contains its build placeholder');
+}
+
+const mapsSandbox = { window: {} };
+vm.runInNewContext(mapsConfigSource, mapsSandbox, { filename: mapsConfigPath });
+if (!mapsSandbox.window.ZVENFIT_MAPS?.sets || !mapsSandbox.window.ZVENFIT_MAPS?.locations) {
+  throw new Error('check-build: maps-config.js does not expose the expected runtime config');
+}
+
 let checkedPages = 0;
 for (const publicHtmlPath of walkHtmlFiles(publicDir)) {
   const sourceHtml = fs.readFileSync(publicHtmlPath, 'utf8');
@@ -56,3 +73,4 @@ if (checkedPages === 0) {
 }
 
 console.log(`check-build: versioned CDN webflow.js verified in ${checkedPages} HTML file(s)`);
+console.log('check-build: generated Yandex Maps runtime config verified');


### PR DESCRIPTION
## Root cause
The maps JSON placeholder appeared first in an ESLint global comment and then in the runtime assignment. The build replaced only the first occurrence, leaving an unresolved identifier in production.

## Fix
- keep exactly one runtime placeholder in maps-config.js
- fail the build unless the template contains exactly one placeholder
- execute the generated config during build verification and require sets/locations
- remove the ineffective X-Frame-Options meta tag

## Verification
- npm run lint:public
- npm run test:build