### PR TITLE
fix: restore production monitoring metrics and alerts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,6 +53,7 @@ jobs:
           npm run test:lead-fn
           npm run test:schedule-fn
           npm run test:lead-import
+          npm run test:monitoring
 
       - name: Verify static production build
         env:

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -21,6 +21,8 @@
 | Schedule function       | `zvenfit-fitbase-schedule`     |
 | Cloud Logging retention | 3 days                         |
 
+Project dashboard: <https://monium.yandex.cloud/projects/folder__b1ge1e4iopttj79hfdfm/dashboards/zvenfit-production-monitoring>
+
 Cloud Logging автоматически показывает свои записи в Monium. Открыть логи:
 
 <https://monium.yandex.cloud/projects/folder__b1ge1e4iopttj79hfdfm/logs>
@@ -163,26 +165,35 @@ Telegram username, UTM и тело ответа Fitbase в лог не попа�
 Отдельный бот Yandex Cloud важен: он сможет сообщить о проблеме, даже если бот
 заявок потерял токен, доступ к чату или был заблокирован.
 
-Создай девять обычных алертов. Семь используют итоговые метрики по логам,
-runtime alert — автоматическую метрику Cloud Functions, storage alert — две
-автоматические метрики YDB:
+Создай девять обычных алертов. Шесть сигналов lead pipeline используют прямые
+OTLP-метрики приложения, два runtime-сигнала — автоматическую метрику Cloud
+Functions, storage alert — две автоматические метрики YDB:
 
 | Alert ID                          | Metric / signal                          | Function | Warning | Alarm   | Window | Delay | No data |
 | --------------------------------- | ---------------------------------------- | -------- | ------: | ------: | -----: | ----: | ------- |
-| `zvenfit_lead_storage_errors`     | `zvenfit_lead_storage_errors_1m`         | `max`    |   `> 0` |  `> 0.5` |     5m |    3m | OK      |
-| `zvenfit_permanent_telegram_failures` | `zvenfit_telegram_delivery_failed_1m` | `max` |   `> 0` |  `> 0.5` |     5m |    3m | OK      |
-| `zvenfit_fitbase_errors`          | `zvenfit_fitbase_errors_5m`              | `max`    |   `> 0` |  `> 0.5` |    10m |    3m | OK      |
+| `zvenfit_lead_storage_errors`     | direct `zvenfit_lead_storage_errors`     | `max`    |   `> 0` |  `> 0.5` |     5m |   30s | OK      |
+| `zvenfit_permanent_telegram_failures` | direct `zvenfit_telegram_delivery_failed_1m` | `max` |   `> 0` |  `> 0.5` |     5m |   30s | OK      |
+| `zvenfit_fitbase_errors`          | `functions_errors`, schedule only        | `max`    |   `> 0` |  `> 0.5` |    10m |   30s | OK      |
 | `zvenfit_function_runtime_errors` | `functions_errors` for both function names | `sum`  |   `> 0` |  `> 0.5` |     5m |   30s | OK      |
-| `zvenfit_ydb_retries`             | `zvenfit_ydb_retries_5m`                 | `sum`    | `> 4.5` |  `> 5.5` |    10m |    3m | OK      |
-| `zvenfit_slow_ydb_operations`     | `zvenfit_ydb_slow_operations_5m`         | `sum`    |   `> 0` |  `> 0.5` |    10m |    3m | OK      |
-| `zvenfit_rate-limited_leads`      | `zvenfit_lead_rate_limited_5m`           | `sum`    |   `> 0` |    `> 5` |    10m |    3m | OK      |
-| `zvenfit_persisted_leads_volume`  | `zvenfit_leads_persisted_5m`             | `sum`    |  `> 10` |   `> 20` |    10m |    3m | OK      |
+| `zvenfit_ydb_retries`             | direct `zvenfit_ydb_retries_5m`          | `sum`    | `> 4.5` |  `> 5.5` |    10m |   30s | OK      |
+| `zvenfit_slow_ydb_operations`     | direct `zvenfit_ydb_slow_operations_5m`  | `sum`    |   `> 0` |  `> 0.5` |    10m |   30s | OK      |
+| `zvenfit_rate-limited_leads`      | direct `zvenfit_lead_rate_limited_5m`    | `sum`    |   `> 0` |    `> 5` |    10m |   30s | OK      |
+| `zvenfit_persisted_leads_volume`  | direct `zvenfit_leads_persisted_5m`      | `sum`    |  `> 10` |   `> 20` |    10m |   30s | OK      |
 | `zvenfit_ydb_storage_usage`       | query `C`, storage used percent           | `last`   | `>= 70` | `>= 85` |    15m |   30s | Warning |
 
 Monium требует `Alarm > Warning`. Для целочисленных счётчиков промежуточное
 значение `0.5` техническое: любая первая точка со значением `1` сразу получает
-статус `Alarm`. Задержка `3m` у log-based алертов учитывает максимальную задержку
-появления агрегата после закрытия окна.
+статус `Alarm`. Прямые и platform metrics используют задержку вычисления `30s`.
+
+Селектор прямой метрики ошибки сохранения:
+
+```text
+{project="folder__b1ge1e4iopttj79hfdfm", cluster="default", service="zvenfit-frontend", name="zvenfit_lead_storage_errors"}
+```
+
+Lead-функция отправляет шесть метрик напрямую в Monium по OTLP с
+`service="zvenfit-frontend"`, поэтому эти alerts не зависят от Preview-конвейера
+метрик по логам. Их имена перечислены в таблице выше.
 
 Селектор автоматической метрики runtime errors:
 
@@ -208,26 +219,24 @@ C: (A / B) * 100
 пользовательские данные, служебные данные и вторичные индексы, поэтому процент
 отражает реальный расход лимита.
 
-Для log-based и runtime алертов отсутствие точек считается `OK`. Для storage
+Для direct и runtime алертов отсутствие точек считается `OK`. Для storage
 отсутствие любой из двух platform metrics считается `Warning`: потеря данных о
 заполнении базы не должна выглядеть как исправное состояние. Во все девять
 алертов добавь оба канала: **ZvenFit Telegram alerts** и **ZvenFit Email alerts**.
 
 ## Проверка доставки алертов
 
-После создания метрик, канала и алертов запусти smoke-тест. Он не вызывает функции,
-не пишет лиды и не содержит персональных данных, но намеренно переводит семь log-based
-алертов в `ALARM`:
+Скрипт ниже пишет синтетические записи без персональных данных и проверяет raw
+logs и оставленные диагностические log metrics. Production alerts от них больше
+не зависят:
 
 ```bash
 bash scripts/test-monitoring-alerts.sh --confirm
 ```
 
-Проверь, что уведомления пришли одновременно в Telegram и email, а затем дождись возврата
-алертов в `OK`. Эта проверка подтверждает доставку обоих каналов. Для runtime alert
-сверь селектор обеих production-функций и политику `No data → OK`: отдельного теста
-канала в Monium нет, а намеренно ронять функции нельзя. Storage alert проверяется по
-живому значению `C`; синтетически заполнять production-базу для его проверки нельзя.
+Доставку каналов проверяй по истории реального runtime alert: и Telegram, и email
+должны иметь `Success` для переходов `Alarm` и `OK`. Намеренно ронять production-
+функции или заполнять production-базу для теста storage alert нельзя.
 
 ## Dashboard
 

--- a/functions/lead-intake/src/handler.ts
+++ b/functions/lead-intake/src/handler.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 
 import { allowedOrigins, corsHeaders, jsonResponse, readBody } from './http';
 import { createLead, hasHoneypotValue, validateLead } from './lead-payload';
+import { withEventMetrics } from './observability/event-metrics';
 import { createInvocationLogger } from './observability/logger';
 import { createInvocationMetrics } from './observability/metrics';
 import {
@@ -116,8 +117,9 @@ function createHandler(overrides: Partial<HandlerDependencies> = {}): CloudHandl
   const dependencies = createDependencies(overrides);
 
   return async (event, context) => {
-    const logger = dependencies.loggerFactory(context);
-    const metrics = dependencies.metricsFactory(context, logger);
+    const baseLogger = dependencies.loggerFactory(context);
+    const metrics = dependencies.metricsFactory(context, baseLogger);
+    const logger = withEventMetrics(baseLogger, metrics);
 
     try {
       if (isTimerEvent(event)) {

--- a/functions/lead-intake/src/observability/__tests__/event-metrics.test.ts
+++ b/functions/lead-intake/src/observability/__tests__/event-metrics.test.ts
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { withEventMetrics } from '../event-metrics';
+
+import type { ApplicationMetrics, JsonObject, LoggerLike } from '../../types';
+
+function capture() {
+  const counters: Array<{ name: string; value: number }> = [];
+  const logs: Array<{ level: string; fields: JsonObject }> = [];
+  const metrics: ApplicationMetrics = {
+    addCounter(name, value = 1) {
+      counters.push({ name, value });
+    },
+    async flush() {},
+  };
+  const logger: LoggerLike = {
+    error(fields) {
+      logs.push({ level: 'error', fields });
+    },
+    info(fields) {
+      logs.push({ level: 'info', fields });
+    },
+    warn(fields) {
+      logs.push({ level: 'warn', fields });
+    },
+  };
+
+  return { counters, logger: withEventMetrics(logger, metrics), logs };
+}
+
+test('records direct counters for lead pipeline events without changing logs', () => {
+  const captured = capture();
+
+  captured.logger.info?.({ event: 'lead_persisted' });
+  captured.logger.warn?.({ event: 'lead_submission_blocked', reason: 'rate_limit' });
+  captured.logger.warn?.({ event: 'ydb_retry', retry_attempts: 3 });
+  captured.logger.warn?.({ event: 'ydb_slow_operation' });
+  captured.logger.error({ event: 'telegram_delivery_failed_permanently' });
+  captured.logger.error({ event: 'telegram_delivery_retry_error' });
+
+  assert.deepEqual(captured.counters, [
+    { name: 'zvenfit_leads_persisted_5m', value: 1 },
+    { name: 'zvenfit_lead_rate_limited_5m', value: 1 },
+    { name: 'zvenfit_ydb_retries_5m', value: 3 },
+    { name: 'zvenfit_ydb_slow_operations_5m', value: 1 },
+    { name: 'zvenfit_telegram_delivery_failed_1m', value: 1 },
+    { name: 'zvenfit_lead_storage_errors', value: 1 },
+  ]);
+  assert.equal(captured.logs.length, 6);
+});
+
+test('ignores non-rate-limit blocks and unrelated events', () => {
+  const captured = capture();
+
+  captured.logger.warn?.({ event: 'lead_submission_blocked', reason: 'honeypot' });
+  captured.logger.info?.({ event: 'telegram_delivery_retry_scheduled' });
+
+  assert.deepEqual(captured.counters, []);
+  assert.equal(captured.logs.length, 2);
+});

--- a/functions/lead-intake/src/observability/event-metrics.ts
+++ b/functions/lead-intake/src/observability/event-metrics.ts
@@ -1,0 +1,56 @@
+import type { ApplicationMetrics, JsonObject, LoggerLike } from '../types';
+
+const EVENT_COUNTERS: Record<string, string> = {
+  lead_persisted: 'zvenfit_leads_persisted_5m',
+  telegram_delivery_failed_permanently: 'zvenfit_telegram_delivery_failed_1m',
+  telegram_delivery_retry_error: 'zvenfit_lead_storage_errors',
+  ydb_retry: 'zvenfit_ydb_retries_5m',
+  ydb_slow_operation: 'zvenfit_ydb_slow_operations_5m',
+};
+
+function counterValue(event: string, fields: JsonObject): number {
+  if (event !== 'ydb_retry') {
+    return 1;
+  }
+
+  const attempts = fields.retry_attempts;
+
+  return typeof attempts === 'number' && Number.isFinite(attempts) && attempts > 0 ? attempts : 1;
+}
+
+function recordEventMetric(metrics: ApplicationMetrics, fields: JsonObject): void {
+  const event = typeof fields.event === 'string' ? fields.event : '';
+  if (event === 'lead_submission_blocked' && fields.reason === 'rate_limit') {
+    metrics.addCounter('zvenfit_lead_rate_limited_5m');
+
+    return;
+  }
+
+  const counter = EVENT_COUNTERS[event];
+  if (counter) {
+    metrics.addCounter(counter, counterValue(event, fields));
+  }
+}
+
+export function withEventMetrics(logger: LoggerLike, metrics: ApplicationMetrics): LoggerLike {
+  return {
+    error(fields, message) {
+      recordEventMetric(metrics, fields);
+      logger.error(fields, message);
+    },
+    info: logger.info
+      ? (fields, message) => {
+          recordEventMetric(metrics, fields);
+          logger.info?.(fields, message);
+        }
+      : undefined,
+    warn: logger.warn
+      ? (fields, message) => {
+          recordEventMetric(metrics, fields);
+          logger.warn?.(fields, message);
+        }
+      : undefined,
+  };
+}
+
+export const _private = { counterValue, recordEventMetric };

--- a/scripts/__tests__/monitoring-config.test.cjs
+++ b/scripts/__tests__/monitoring-config.test.cjs
@@ -56,7 +56,7 @@ test('anti-spam and accepted lead volume thresholds are explicit', () => {
   const rateAlert = config.alerts.find(alert => alert.id === 'zvenfit_rate-limited_leads');
   const volumeAlert = config.alerts.find(alert => alert.id === 'zvenfit_persisted_leads_volume');
 
-  assert.deepEqual(rateMetric.filters, { reason: 'rate_limit' });
+  assert.deepEqual(rateMetric.filters, { 'meta.reason': 'rate_limit' });
   assert.deepEqual(
     { warning: rateAlert.warning, alarm: rateAlert.alarm, window: rateAlert.window },
     { warning: 0, alarm: 5, window: '10m' },
@@ -67,14 +67,11 @@ test('anti-spam and accepted lead volume thresholds are explicit', () => {
   );
 });
 
-test('log-derived alerts account for aggregate delivery lag', () => {
+test('alerts no longer depend on the Preview log aggregate pipeline', () => {
   const metricIds = new Set(config.logMetrics.map(metric => metric.id));
   const logAlerts = config.alerts.filter(alert => metricIds.has(alert.metricId));
 
-  assert.equal(logAlerts.length, 7);
-  for (const alert of logAlerts) {
-    assert.equal(alert.delay, '3m', `${alert.id} must wait for log aggregate delivery`);
-  }
+  assert.equal(logAlerts.length, 0);
 });
 
 test('YDB retry thresholds expose reachable Warning and Alarm states', () => {
@@ -110,6 +107,39 @@ test('runtime alert covers both production functions', () => {
   assert.doesNotMatch(monitoringDocs, /кнопк[^\n]*тестирован[^\n]*канал/i);
 });
 
+test('lead storage alert uses the direct OTLP application metric', () => {
+  const alert = config.alerts.find(item => item.id === 'zvenfit_lead_storage_errors');
+
+  assert.match(alert.metricSelector, /service="zvenfit-frontend"/);
+  assert.match(alert.metricSelector, /name="zvenfit_lead_storage_errors"/);
+});
+
+test('lead pipeline alerts use direct OTLP application metrics', () => {
+  const directIds = [
+    'zvenfit_lead_storage_errors',
+    'zvenfit_permanent_telegram_failures',
+    'zvenfit_ydb_retries',
+    'zvenfit_slow_ydb_operations',
+    'zvenfit_rate-limited_leads',
+    'zvenfit_persisted_leads_volume',
+  ];
+
+  for (const id of directIds) {
+    const alert = config.alerts.find(item => item.id === id);
+    assert.match(alert.metricSelector, /service="zvenfit-frontend"/, `${id} is not direct`);
+    assert.equal(alert.delay, '30s', `${id} should use direct metric latency`);
+  }
+});
+
+test('Fitbase alert uses the schedule runtime error metric', () => {
+  const alert = config.alerts.find(item => item.id === 'zvenfit_fitbase_errors');
+
+  assert.match(alert.metricSelector, /service="serverless-functions"/);
+  assert.match(alert.metricSelector, /name="functions_errors"/);
+  assert.match(alert.metricSelector, /resource_id="zvenfit-fitbase-schedule"/);
+  assert.equal(alert.delay, '30s');
+});
+
 test('transient Telegram retries remain log-only', () => {
   const monitoredEvents = config.logMetrics.flatMap(metric => metric.events);
 
@@ -122,8 +152,10 @@ test('production log source and retention are explicit', () => {
   assert.deepEqual(config.source, {
     cluster: 'default',
     service: 'default',
-    application: 'zvenfit-frontend',
-    environment: 'production',
+    labels: {
+      'meta.application': 'zvenfit-frontend',
+      'meta.environment': 'production',
+    },
     retentionDays: 3,
   });
   assert.deepEqual(config.metricOutput, {
@@ -139,6 +171,8 @@ test('every log selector is isolated by repository and environment', () => {
   assert.match(smokeScript, /APPLICATION_NAME="zvenfit-frontend"/);
   assert.match(smokeScript, /MONITORING_ENVIRONMENT="\$\{NODE_ENV:-production\}"/);
   assert.match(monitoringDocs, /service="logging_aggregates"/);
+  assert.doesNotMatch(monitoringDocs, /[,{]\s*application="zvenfit-frontend"/);
+  assert.doesNotMatch(monitoringDocs, /[,{]\s*environment="production"/);
 });
 
 test('manual provisioning and notification channel requirements are explicit', () => {
@@ -181,5 +215,5 @@ test('monitoring smoke script requires confirmation and covers every log metric'
   }
 
   assert.match(smokeScript, /reason\\?":\\?"rate_limit/);
-  assert.match(smokeScript, /Expect seven log-based alerts/);
+  assert.match(smokeScript, /No production alert depends on these Preview log aggregates/);
 });

--- a/scripts/monitoring.config.json
+++ b/scripts/monitoring.config.json
@@ -3,8 +3,10 @@
   "source": {
     "cluster": "default",
     "service": "default",
-    "application": "zvenfit-frontend",
-    "environment": "production",
+    "labels": {
+      "meta.application": "zvenfit-frontend",
+      "meta.environment": "production"
+    },
     "retentionDays": 3
   },
   "metricOutput": {
@@ -71,7 +73,7 @@
     {
       "id": "zvenfit_lead_rate_limited_5m",
       "events": ["lead_submission_blocked"],
-      "filters": { "reason": "rate_limit" },
+      "filters": { "meta.reason": "rate_limit" },
       "aggregation": "count",
       "window": "5m"
     },
@@ -85,35 +87,35 @@
   "alerts": [
     {
       "id": "zvenfit_lead_storage_errors",
-      "metricId": "zvenfit_lead_storage_errors_1m",
+      "metricSelector": "{project=\"folder__b1ge1e4iopttj79hfdfm\", cluster=\"default\", service=\"zvenfit-frontend\", name=\"zvenfit_lead_storage_errors\"}",
       "aggregation": "max",
       "operator": ">",
       "warning": 0,
       "alarm": 0.5,
       "window": "5m",
-      "delay": "3m",
+      "delay": "30s",
       "noData": "OK"
     },
     {
       "id": "zvenfit_permanent_telegram_failures",
-      "metricId": "zvenfit_telegram_delivery_failed_1m",
+      "metricSelector": "{project=\"folder__b1ge1e4iopttj79hfdfm\", cluster=\"default\", service=\"zvenfit-frontend\", name=\"zvenfit_telegram_delivery_failed_1m\"}",
       "aggregation": "max",
       "operator": ">",
       "warning": 0,
       "alarm": 0.5,
       "window": "5m",
-      "delay": "3m",
+      "delay": "30s",
       "noData": "OK"
     },
     {
       "id": "zvenfit_fitbase_errors",
-      "metricId": "zvenfit_fitbase_errors_5m",
+      "metricSelector": "{project=\"folder__b1ge1e4iopttj79hfdfm\", cluster=\"default\", service=\"serverless-functions\", name=\"functions_errors\", resource_id=\"zvenfit-fitbase-schedule\"}",
       "aggregation": "max",
       "operator": ">",
       "warning": 0,
       "alarm": 0.5,
       "window": "10m",
-      "delay": "3m",
+      "delay": "30s",
       "noData": "OK"
     },
     {
@@ -129,46 +131,46 @@
     },
     {
       "id": "zvenfit_ydb_retries",
-      "metricId": "zvenfit_ydb_retries_5m",
+      "metricSelector": "{project=\"folder__b1ge1e4iopttj79hfdfm\", cluster=\"default\", service=\"zvenfit-frontend\", name=\"zvenfit_ydb_retries_5m\"}",
       "aggregation": "sum",
       "operator": ">",
       "warning": 4.5,
       "alarm": 5.5,
       "window": "10m",
-      "delay": "3m",
+      "delay": "30s",
       "noData": "OK"
     },
     {
       "id": "zvenfit_slow_ydb_operations",
-      "metricId": "zvenfit_ydb_slow_operations_5m",
+      "metricSelector": "{project=\"folder__b1ge1e4iopttj79hfdfm\", cluster=\"default\", service=\"zvenfit-frontend\", name=\"zvenfit_ydb_slow_operations_5m\"}",
       "aggregation": "sum",
       "operator": ">",
       "warning": 0,
       "alarm": 0.5,
       "window": "10m",
-      "delay": "3m",
+      "delay": "30s",
       "noData": "OK"
     },
     {
       "id": "zvenfit_rate-limited_leads",
-      "metricId": "zvenfit_lead_rate_limited_5m",
+      "metricSelector": "{project=\"folder__b1ge1e4iopttj79hfdfm\", cluster=\"default\", service=\"zvenfit-frontend\", name=\"zvenfit_lead_rate_limited_5m\"}",
       "aggregation": "sum",
       "operator": ">",
       "warning": 0,
       "alarm": 5,
       "window": "10m",
-      "delay": "3m",
+      "delay": "30s",
       "noData": "OK"
     },
     {
       "id": "zvenfit_persisted_leads_volume",
-      "metricId": "zvenfit_leads_persisted_5m",
+      "metricSelector": "{project=\"folder__b1ge1e4iopttj79hfdfm\", cluster=\"default\", service=\"zvenfit-frontend\", name=\"zvenfit_leads_persisted_5m\"}",
       "aggregation": "sum",
       "operator": ">",
       "warning": 10,
       "alarm": 20,
       "window": "10m",
-      "delay": "3m",
+      "delay": "30s",
       "noData": "OK"
     },
     {

--- a/scripts/test-monitoring-alerts.sh
+++ b/scripts/test-monitoring-alerts.sh
@@ -55,6 +55,6 @@ for _ in {1..21}; do
 done
 
 echo "test-monitoring-alerts: synthetic events written to ${LOG_GROUP_NAME}"
-echo "Expect seven log-based alerts to enter ALARM after their evaluation windows."
+echo "No production alert depends on these Preview log aggregates; use this output for diagnostics only."
 echo "The YDB storage alert must be checked against live platform metrics, not synthetic logs."
 echo "Verify Telegram and email delivery, then acknowledge the test alerts in Monitoring."


### PR DESCRIPTION
Summary:
- publish lead pipeline events as direct monitoring metrics
- switch production alerts from delayed log-derived metrics to direct/platform metrics
- add monitoring configuration tests and production monitoring documentation
- run monitoring checks in CI

Verification:
- npm run lint:public
- npm run test:lead-fn
- npm run test:schedule-fn
- npm test
- npm run test:monitoring
- npm run build