### PR TITLE
fix: await Monium export in serverless invocations

### DIFF
--- a/functions/lead-intake/package-lock.json
+++ b/functions/lead-intake/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@opentelemetry/api": "1.9.1",
+        "@opentelemetry/core": "2.10.0",
         "@opentelemetry/exporter-metrics-otlp-proto": "0.221.0",
         "@opentelemetry/sdk-metrics": "2.10.0",
         "@ydbjs/auth": "6.3.1",

--- a/functions/lead-intake/package.json
+++ b/functions/lead-intake/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@opentelemetry/api": "1.9.1",
+    "@opentelemetry/core": "2.10.0",
     "@opentelemetry/exporter-metrics-otlp-proto": "0.221.0",
     "@opentelemetry/sdk-metrics": "2.10.0",
     "@ydbjs/auth": "6.3.1",

--- a/functions/lead-intake/src/observability/__tests__/metrics.test.ts
+++ b/functions/lead-intake/src/observability/__tests__/metrics.test.ts
@@ -1,7 +1,9 @@
+import { ExportResultCode } from '@opentelemetry/core';
+import { AggregationTemporality, type PushMetricExporter, type ResourceMetrics } from '@opentelemetry/sdk-metrics';
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { createInvocationMetrics, type InvocationMetrics } from '../metrics';
+import { _private, createInvocationMetrics, type InvocationMetrics } from '../metrics';
 
 import type { JsonObject, LoggerLike } from '../../types';
 
@@ -170,4 +172,62 @@ test('bounds the exporter timeout', () => {
   }
 
   assert.deepEqual(observedTimeouts, [100, 5000]);
+});
+
+test('collects once and waits for the exporter callback before shutdown', async () => {
+  let exportedMetrics: ResourceMetrics | undefined;
+  let callbackCompleted = false;
+  let shutdownCalls = 0;
+  const exporter: PushMetricExporter = {
+    export(metrics, resultCallback) {
+      exportedMetrics = metrics;
+      setTimeout(() => {
+        callbackCompleted = true;
+        resultCallback({ code: ExportResultCode.SUCCESS });
+      }, 10);
+    },
+    async forceFlush() {},
+    async shutdown() {
+      shutdownCalls += 1;
+    },
+  };
+  const transport = _private.createOtelTransport(
+    { endpoint: 'https://example.test', headers: {}, timeoutMs: 100 },
+    () => exporter,
+  );
+
+  transport.addCounter('zvenfit_test_events', 2, { outcome: 'stored' });
+  const flushPromise = transport.flush();
+  assert.equal(callbackCompleted, false);
+  await flushPromise;
+
+  assert.equal(callbackCompleted, true);
+  assert.equal(shutdownCalls, 1);
+  const metric = exportedMetrics?.scopeMetrics
+    .flatMap(scope => scope.metrics)
+    .find(item => item.descriptor.name === 'zvenfit_test_events');
+  assert.ok(metric);
+  assert.equal(metric.aggregationTemporality, AggregationTemporality.CUMULATIVE);
+  assert.equal(metric.dataPoints[0]?.value, 2);
+  assert.deepEqual(metric.dataPoints[0]?.attributes, { outcome: 'stored' });
+});
+
+test('rejects when the exporter callback reports a failure', async () => {
+  const exporter: PushMetricExporter = {
+    export(_metrics, resultCallback) {
+      resultCallback({
+        code: ExportResultCode.FAILED,
+        error: Object.assign(new Error('collector rejected metrics'), { code: 'collector_rejected' }),
+      });
+    },
+    async forceFlush() {},
+    async shutdown() {},
+  };
+  const transport = _private.createOtelTransport(
+    { endpoint: 'https://example.test', headers: {}, timeoutMs: 100 },
+    () => exporter,
+  );
+
+  transport.addCounter('zvenfit_test_events', 1);
+  await assert.rejects(transport.flush(), { code: 'collector_rejected' });
 });

--- a/functions/lead-intake/src/observability/metrics.ts
+++ b/functions/lead-intake/src/observability/metrics.ts
@@ -1,8 +1,7 @@
-import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-proto';
-import { AggregationTemporality, MeterProvider, PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics';
+import { createOtelTransport, type MetricsTransport, type MetricsTransportOptions } from './otel-transport';
 
 import type { ApplicationMetrics, FunctionContext, LoggerLike } from '../types';
-import type { Meter, MetricAttributes } from '@opentelemetry/api';
+import type { MetricAttributes } from '@opentelemetry/api';
 
 const DEFAULT_ENDPOINT = 'https://ingest.monium.yandex.cloud/otlp/v1/metrics';
 const DEFAULT_CLUSTER = 'default';
@@ -10,9 +9,6 @@ const DEFAULT_SERVICE = 'zvenfit-frontend';
 const DEFAULT_TIMEOUT_MS = 1000;
 const MIN_TIMEOUT_MS = 100;
 const MAX_TIMEOUT_MS = 5000;
-const EXPORT_INTERVAL_MS = 60_000;
-const METER_NAME = 'zvenfit-lead-intake';
-const METER_VERSION = '1';
 
 export interface InvocationMetrics extends ApplicationMetrics {
   addCounter(name: string, value?: number, attributes?: MetricAttributes): void;
@@ -20,67 +16,11 @@ export interface InvocationMetrics extends ApplicationMetrics {
   flush(): Promise<void>;
 }
 
-interface MetricsTransport {
-  addCounter(name: string, value: number, attributes?: MetricAttributes): void;
-  recordGauge(name: string, value: number, attributes?: MetricAttributes): void;
-  flush(): Promise<void>;
-}
-
-interface MetricsTransportOptions {
-  endpoint: string;
-  headers: Record<string, string>;
-  timeoutMs: number;
-}
-
 type MetricsTransportFactory = (options: MetricsTransportOptions) => MetricsTransport;
 
 interface CreateInvocationMetricsOptions {
   env?: NodeJS.ProcessEnv;
   transportFactory?: MetricsTransportFactory;
-}
-
-class OtelMetricsTransport implements MetricsTransport {
-  private readonly counters = new Map<string, ReturnType<Meter['createCounter']>>();
-  private readonly gauges = new Map<string, ReturnType<Meter['createGauge']>>();
-  private readonly provider: MeterProvider;
-  private readonly meter: Meter;
-  private readonly timeoutMs: number;
-
-  public constructor(provider: MeterProvider, meter: Meter, timeoutMs: number) {
-    this.provider = provider;
-    this.meter = meter;
-    this.timeoutMs = timeoutMs;
-  }
-
-  public addCounter(name: string, value: number, attributes?: MetricAttributes): void {
-    let counter = this.counters.get(name);
-    if (!counter) {
-      counter = this.meter.createCounter(name);
-      this.counters.set(name, counter);
-    }
-    counter.add(value, attributes);
-  }
-
-  public recordGauge(name: string, value: number, attributes?: MetricAttributes): void {
-    let gauge = this.gauges.get(name);
-    if (!gauge) {
-      gauge = this.meter.createGauge(name);
-      this.gauges.set(name, gauge);
-    }
-    gauge.record(value, attributes);
-  }
-
-  public async flush(): Promise<void> {
-    const exportResult = await settle(this.provider.forceFlush({ timeoutMillis: this.timeoutMs }));
-    const shutdownResult = await settle(this.provider.shutdown({ timeoutMillis: this.timeoutMs }));
-
-    if (exportResult.status === 'rejected') {
-      throw exportResult.reason;
-    }
-    if (shutdownResult.status === 'rejected') {
-      throw shutdownResult.reason;
-    }
-  }
 }
 
 class LazyInvocationMetrics implements InvocationMetrics {
@@ -143,13 +83,6 @@ const NOOP_METRICS: InvocationMetrics = {
   async flush() {},
 };
 
-function settle<T>(promise: Promise<T>): Promise<PromiseSettledResult<T>> {
-  return promise.then(
-    value => ({ status: 'fulfilled', value }),
-    reason => ({ status: 'rejected', reason }),
-  );
-}
-
 function metricErrorCode(error: unknown): string {
   if (!(error instanceof Error)) {
     return 'metrics_error';
@@ -180,23 +113,6 @@ function metricsTimeoutMs(env: NodeJS.ProcessEnv): number {
   }
 
   return Math.min(Math.max(configured, MIN_TIMEOUT_MS), MAX_TIMEOUT_MS);
-}
-
-function createOtelTransport(options: MetricsTransportOptions): MetricsTransport {
-  const exporter = new OTLPMetricExporter({
-    url: options.endpoint,
-    headers: options.headers,
-    timeoutMillis: options.timeoutMs,
-    temporalityPreference: AggregationTemporality.DELTA,
-  });
-  const reader = new PeriodicExportingMetricReader({
-    exporter,
-    exportIntervalMillis: EXPORT_INTERVAL_MS,
-    exportTimeoutMillis: options.timeoutMs,
-  });
-  const provider = new MeterProvider({ readers: [reader] });
-
-  return new OtelMetricsTransport(provider, provider.getMeter(METER_NAME, METER_VERSION), options.timeoutMs);
 }
 
 export function createInvocationMetrics(
@@ -245,6 +161,7 @@ export const _private = {
   DEFAULT_SERVICE,
   MAX_TIMEOUT_MS,
   MIN_TIMEOUT_MS,
+  createOtelTransport,
   metricsEnabled,
   metricsTimeoutMs,
 };

--- a/functions/lead-intake/src/observability/otel-transport.ts
+++ b/functions/lead-intake/src/observability/otel-transport.ts
@@ -1,0 +1,191 @@
+import { ExportResultCode } from '@opentelemetry/core';
+import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-proto';
+import {
+  AggregationTemporality,
+  MeterProvider,
+  MetricReader,
+  type PushMetricExporter,
+  type ResourceMetrics,
+} from '@opentelemetry/sdk-metrics';
+
+import type { Meter, MetricAttributes } from '@opentelemetry/api';
+
+const METER_NAME = 'zvenfit-lead-intake';
+const METER_VERSION = '1';
+
+export interface MetricsTransport {
+  addCounter(name: string, value: number, attributes?: MetricAttributes): void;
+  recordGauge(name: string, value: number, attributes?: MetricAttributes): void;
+  flush(): Promise<void>;
+}
+
+export interface MetricsTransportOptions {
+  endpoint: string;
+  headers: Record<string, string>;
+  timeoutMs: number;
+}
+
+type MetricsExporterFactory = (options: MetricsTransportOptions) => PushMetricExporter;
+
+class OneShotMetricReader extends MetricReader {
+  protected async onForceFlush(): Promise<void> {}
+
+  protected async onShutdown(): Promise<void> {}
+}
+
+class OtelMetricsTransport implements MetricsTransport {
+  private readonly counters = new Map<string, ReturnType<Meter['createCounter']>>();
+  private readonly gauges = new Map<string, ReturnType<Meter['createGauge']>>();
+  private readonly provider: MeterProvider;
+  private readonly reader: MetricReader;
+  private readonly exporter: PushMetricExporter;
+  private readonly meter: Meter;
+  private readonly timeoutMs: number;
+
+  public constructor(
+    provider: MeterProvider,
+    reader: MetricReader,
+    exporter: PushMetricExporter,
+    meter: Meter,
+    timeoutMs: number,
+  ) {
+    this.provider = provider;
+    this.reader = reader;
+    this.exporter = exporter;
+    this.meter = meter;
+    this.timeoutMs = timeoutMs;
+  }
+
+  public addCounter(name: string, value: number, attributes?: MetricAttributes): void {
+    let counter = this.counters.get(name);
+    if (!counter) {
+      counter = this.meter.createCounter(name);
+      this.counters.set(name, counter);
+    }
+    counter.add(value, attributes);
+  }
+
+  public recordGauge(name: string, value: number, attributes?: MetricAttributes): void {
+    let gauge = this.gauges.get(name);
+    if (!gauge) {
+      gauge = this.meter.createGauge(name);
+      this.gauges.set(name, gauge);
+    }
+    gauge.record(value, attributes);
+  }
+
+  public async flush(): Promise<void> {
+    let exportFailure: unknown;
+
+    try {
+      const { resourceMetrics, errors } = await this.reader.collect({ timeoutMillis: this.timeoutMs });
+      if (errors.length > 0) {
+        throw normalizeMetricError(errors[0], 'metrics_collection_failed');
+      }
+      if (resourceMetrics.scopeMetrics.length > 0) {
+        await exportCollectedMetrics(this.exporter, resourceMetrics, this.timeoutMs);
+      }
+      await this.exporter.forceFlush();
+    } catch (error) {
+      exportFailure = normalizeMetricError(error, 'metrics_export_failed');
+    }
+
+    const [providerShutdown, exporterShutdown] = await Promise.all([
+      settle(this.provider.shutdown({ timeoutMillis: this.timeoutMs })),
+      settle(this.exporter.shutdown()),
+    ]);
+
+    if (exportFailure !== undefined) {
+      throw exportFailure;
+    }
+    if (providerShutdown.status === 'rejected') {
+      throw providerShutdown.reason;
+    }
+    if (exporterShutdown.status === 'rejected') {
+      throw exporterShutdown.reason;
+    }
+  }
+}
+
+function settle<T>(promise: Promise<T>): Promise<PromiseSettledResult<T>> {
+  return promise.then(
+    value => ({ status: 'fulfilled', value }),
+    reason => ({ status: 'rejected', reason }),
+  );
+}
+
+function normalizeMetricError(error: unknown, code: string): Error {
+  if (error instanceof Error) {
+    return error;
+  }
+
+  return Object.assign(new Error(code), { code });
+}
+
+function exportCollectedMetrics(
+  exporter: PushMetricExporter,
+  resourceMetrics: ResourceMetrics,
+  timeoutMs: number,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let completed = false;
+    const timeoutState: { value?: NodeJS.Timeout } = {};
+    const finish = (error?: Error) => {
+      if (completed) {
+        return;
+      }
+      completed = true;
+      if (timeoutState.value) {
+        clearTimeout(timeoutState.value);
+      }
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    };
+    timeoutState.value = setTimeout(() => {
+      finish(Object.assign(new Error('Metric export timed out'), { code: 'metrics_export_timeout' }));
+    }, timeoutMs);
+
+    try {
+      exporter.export(resourceMetrics, result => {
+        finish(
+          result.code === ExportResultCode.SUCCESS
+            ? undefined
+            : (result.error ?? Object.assign(new Error('Metric export failed'), { code: 'metrics_export_failed' })),
+        );
+      });
+    } catch (error) {
+      finish(normalizeMetricError(error, 'metrics_export_failed'));
+    }
+  });
+}
+
+function createOtelExporter(options: MetricsTransportOptions): PushMetricExporter {
+  return new OTLPMetricExporter({
+    url: options.endpoint,
+    headers: options.headers,
+    timeoutMillis: options.timeoutMs,
+    temporalityPreference: AggregationTemporality.CUMULATIVE,
+  });
+}
+
+export function createOtelTransport(
+  options: MetricsTransportOptions,
+  exporterFactory: MetricsExporterFactory = createOtelExporter,
+): MetricsTransport {
+  const exporter = exporterFactory(options);
+  const reader = new OneShotMetricReader({
+    aggregationTemporalitySelector: () => AggregationTemporality.CUMULATIVE,
+  });
+  const provider = new MeterProvider({ readers: [reader] });
+
+  return new OtelMetricsTransport(
+    provider,
+    reader,
+    exporter,
+    provider.getMeter(METER_NAME, METER_VERSION),
+    options.timeoutMs,
+  );
+}


### PR DESCRIPTION
## Что исправлено
- заменён периодический reader на одноразовый collect/export для Cloud Functions
- функция ждёт callback OTLP-экспортера до завершения invocation
- cumulative temporality сохраняет счётчики событий без искусственного rate
- ошибки коллектора и таймауты больше не проглатываются SDK

## Проверки
- npm test (functions/lead-intake): 36 unit + artifact
- npm run lint:public
- npm run test:schedule-fn
- npm run test:lead-import
- npm run test:monitoring
- npm run test:build