### PR TITLE
fix: flush metrics after handler completion

### DIFF
--- a/functions/lead-intake/src/__tests__/handler.test.ts
+++ b/functions/lead-intake/src/__tests__/handler.test.ts
@@ -113,6 +113,38 @@ test('POST persists a pending lead and returns before Telegram delivery', async 
   assert.deepEqual(savedLead.utm, { utm_source: 'direct' });
 });
 
+test('flushes metrics after asynchronous POST events have been recorded', async () => {
+  const order: string[] = [];
+  const store: StoreMock = {
+    async saveLead() {
+      await Promise.resolve();
+      order.push('lead_saved');
+
+      return { created: true, telegramStatus: 'pending' };
+    },
+  };
+  const handler = _private.createHandler(
+    dependencies(store, {
+      loggerFactory: () => ({
+        error() {},
+        info() {},
+      }),
+      metricsFactory: () => ({
+        addCounter(name) {
+          order.push(`metric:${name}`);
+        },
+        async flush() {
+          order.push('metrics_flushed');
+        },
+      }),
+    }),
+  );
+
+  await invokeHttp(handler);
+
+  assert.deepEqual(order, ['lead_saved', 'metric:zvenfit_leads_persisted_5m', 'metrics_flushed']);
+});
+
 test('timer keeps a persisted lead pending when Telegram is unavailable', async () => {
   let failedDelivery: FailedDelivery | undefined;
   const store: StoreMock = {

--- a/functions/lead-intake/src/handler.ts
+++ b/functions/lead-intake/src/handler.ts
@@ -123,7 +123,9 @@ function createHandler(overrides: Partial<HandlerDependencies> = {}): CloudHandl
 
     try {
       if (isTimerEvent(event)) {
-        return retryPendingLeads(dependencies, logger);
+        const retrySummary = await retryPendingLeads(dependencies, logger);
+
+        return retrySummary;
       }
 
       const origins = allowedOrigins();
@@ -156,7 +158,9 @@ function createHandler(overrides: Partial<HandlerDependencies> = {}): CloudHandl
 
       const sourceIp = event.requestContext?.identity?.sourceIp?.trim() || '';
 
-      return persistLead(body, dependencies, logger, metrics, headers, sourceIp);
+      const response = await persistLead(body, dependencies, logger, metrics, headers, sourceIp);
+
+      return response;
     } finally {
       await metrics.flush();
     }


### PR DESCRIPTION
## Причина
`return` передавал незавершённый Promise из `persistLead`/retry worker, поэтому `finally` вызывал `metrics.flush()` до записи событий.

## Исправление
- handler ждёт завершения POST и timer pipeline перед возвратом
- `finally` экспортирует уже записанные метрики
- регрессионный тест проверяет порядок `lead_saved -> metric -> flush`

## Проверки
- npm test (functions/lead-intake): 37 unit + artifact
- npm run lint:public