### PR TITLE
fix: exclude YDB cold starts from latency metrics

### DIFF
--- a/functions/lead-intake/src/ydb/context.ts
+++ b/functions/lead-intake/src/ydb/context.ts
@@ -41,6 +41,17 @@ export function observed<T>(operation: string, logger: LoggerLike | undefined, c
   return observeYdbOperation(operation, logger, callback);
 }
 
+// Cold-start connection setup is not query latency and must not trigger the slow-operation alert.
+export async function observedSql<T>(
+  operation: string,
+  logger: LoggerLike | undefined,
+  callback: (sql: YdbClient['sql']) => Promise<T>,
+): Promise<T> {
+  const sql = await getSql();
+
+  return observed(operation, logger, () => callback(sql));
+}
+
 export function firstResultSet(resultSets: unknown): SqlRow[] {
   return Array.isArray(resultSets) && Array.isArray(resultSets[0]) ? (resultSets[0] as SqlRow[]) : [];
 }

--- a/functions/lead-intake/src/ydb/lead-persistence.ts
+++ b/functions/lead-intake/src/ydb/lead-persistence.ts
@@ -1,13 +1,5 @@
 import { tableName } from './config';
-import {
-  getSql,
-  firstResultSet,
-  observed,
-  telegramStatus,
-  transactionOptions,
-  ydbTimestamp,
-  ydbUint32,
-} from './context';
+import { firstResultSet, observedSql, telegramStatus, transactionOptions, ydbTimestamp, ydbUint32 } from './context';
 
 import type { Lead, LoggerLike, TelegramStatus } from '../types';
 
@@ -15,8 +7,7 @@ export async function saveLead(
   lead: Lead,
   { logger }: { logger?: LoggerLike } = {},
 ): Promise<{ created: boolean; telegramStatus: TelegramStatus }> {
-  return observed('save_lead', logger, async () => {
-    const sql = await getSql();
+  return observedSql('save_lead', logger, async sql => {
     const leadsTable = sql.identifier(tableName());
 
     return sql.begin(transactionOptions(), async tx => {
@@ -70,8 +61,7 @@ export async function importDeliveredLead(
   lead: Lead & { notifiedAt?: Date },
   { logger }: { logger?: LoggerLike } = {},
 ): Promise<{ created: boolean; telegramStatus: TelegramStatus }> {
-  return observed('import_delivered_lead', logger, async () => {
-    const sql = await getSql();
+  return observedSql('import_delivered_lead', logger, async sql => {
     const leadsTable = sql.identifier(tableName());
 
     return sql.begin(transactionOptions(), async tx => {

--- a/functions/lead-intake/src/ydb/rate-limit.ts
+++ b/functions/lead-intake/src/ydb/rate-limit.ts
@@ -1,7 +1,7 @@
 import { createHmac } from 'node:crypto';
 
 import { parsePositiveInt, rateLimitsTableName } from './config';
-import { firstResultSet, getSql, observed, transactionOptions, ydbTimestamp, ydbUint32 } from './context';
+import { firstResultSet, observedSql, transactionOptions, ydbTimestamp, ydbUint32 } from './context';
 
 import type { LoggerLike } from '../types';
 
@@ -52,9 +52,9 @@ export async function consumeLeadRateLimit({
   now: Date;
   logger?: LoggerLike;
 }): Promise<boolean> {
-  return observed('lead_rate_limit', logger, async () => {
-    const { maxRequests, windowSeconds, secret } = settings();
-    const sql = await getSql();
+  const { maxRequests, windowSeconds, secret } = settings();
+
+  return observedSql('lead_rate_limit', logger, async sql => {
     const rateLimitsTable = sql.identifier(rateLimitsTableName());
     const key = rateKey(sourceIp, now, windowSeconds, secret);
     const expiresAt = new Date(windowStart(now, windowSeconds) + COUNTER_RETENTION_MS);

--- a/functions/lead-intake/src/ydb/telegram-queue.ts
+++ b/functions/lead-intake/src/ydb/telegram-queue.ts
@@ -1,8 +1,7 @@
 import { dueIndexName, tableName } from './config';
 import {
   firstResultSet,
-  getSql,
-  observed,
+  observedSql,
   rowToLead,
   stringValue,
   timed,
@@ -27,8 +26,7 @@ export async function claimForTelegram({
   deliveryToken: string;
   logger?: LoggerLike;
 }): Promise<ClaimedLead | null> {
-  return observed('claim_for_telegram', logger, async () => {
-    const sql = await getSql();
+  return observedSql('claim_for_telegram', logger, async sql => {
     const leadsTable = sql.identifier(tableName());
 
     return sql.begin(transactionOptions(), async tx => {
@@ -90,8 +88,7 @@ export async function markTelegramDelivered({
   notifiedAt: Date;
   logger?: LoggerLike;
 }): Promise<void> {
-  return observed('mark_telegram_delivered', logger, async () => {
-    const sql = await getSql();
+  return observedSql('mark_telegram_delivered', logger, async sql => {
     const leadsTable = sql.identifier(tableName());
     await timed(
       sql`
@@ -126,8 +123,7 @@ export async function markTelegramFailed({
   terminal: boolean;
   logger?: LoggerLike;
 }): Promise<void> {
-  return observed('mark_telegram_failed', logger, async () => {
-    const sql = await getSql();
+  return observedSql('mark_telegram_failed', logger, async sql => {
     const leadsTable = sql.identifier(tableName());
     const status = terminal ? 'failed' : 'pending';
     const dueAt = terminal ? sql.fragment`NULL` : sql.fragment`${ydbTimestamp(failedAt)}`;
@@ -158,8 +154,7 @@ export async function listTelegramCandidates({
   limit: number;
   logger?: LoggerLike;
 }): Promise<string[]> {
-  return observed('list_telegram_candidates', logger, async () => {
-    const sql = await getSql();
+  return observedSql('list_telegram_candidates', logger, async sql => {
     const leadsTable = sql.identifier(tableName());
     const dueIndex = sql.identifier(dueIndexName());
     const safeLimit = Math.min(Math.max(Number(limit) || 1, 1), 100);


### PR DESCRIPTION
## Что исправлено
- инициализация YDB-клиента исключена из замера SQL latency
- slow-operation alert теперь учитывает только выполнение запросов
- все YDB-операции используют единый helper для корректной границы измерения

## Проверка
- npm run test:lead-fn
- npm run lint:public
- git diff --check