### PR TITLE
fix: reduce CI service account privileges

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,6 +65,7 @@ jobs:
   deploy-function:
     needs: quality-checks
     runs-on: ubuntu-latest
+    environment: production
     outputs:
       function_url: ${{ steps.get-url.outputs.url }}
 
@@ -138,6 +139,7 @@ jobs:
   deploy-schedule-function:
     needs: quality-checks
     runs-on: ubuntu-latest
+    environment: production
     outputs:
       function_url: ${{ steps.get-schedule-url.outputs.url }}
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -45,7 +45,7 @@ yc config get folder-id  # b1g...
 
 ```bash
 export YC_FOLDER_ID=$(yc config get folder-id)
-export SA_NAME=github-ci-zvenfit
+export SA_NAME=zvenfit-ci-sa
 
 # Создать SA
 yc iam service-account create --name $SA_NAME
@@ -55,22 +55,7 @@ SA_ID=$(yc iam service-account get --name $SA_NAME --format json | jq -r '.id')
 
 yc resource-manager folder add-access-binding \
   --id $YC_FOLDER_ID \
-  --role functions.admin \
-  --service-account-id $SA_ID
-
-yc resource-manager folder add-access-binding \
-  --id $YC_FOLDER_ID \
-  --role iam.serviceAccounts.user \
-  --service-account-id $SA_ID
-
-yc resource-manager folder add-access-binding \
-  --id $YC_FOLDER_ID \
-  --role functions.functionInvoker \
-  --service-account-id $SA_ID
-
-yc resource-manager folder add-access-binding \
-  --id $YC_FOLDER_ID \
-  --role ydb.editor \
+  --role functions.editor \
   --service-account-id $SA_ID
 
 # Создать авторизованный ключ
@@ -126,8 +111,58 @@ rm sa-key.json
 | `MONIUM_METRICS_TIMEOUT_MS` | `1000`     | Максимальное ожидание отправки метрик в конце вызова                       |
 | `NODE_ENV`              | `production`    | Значение поля `environment` в structured logs функций                     |
 
-Для production создай отдельный runtime SA, выдай ему `ydb.editor` на базу и
-`functions.functionInvoker` на функцию, а также `monium.telemetry.writer` на каталог.
+До первого CI deploy создай YDB, обе функции и отдельный runtime SA под учётной
+записью администратора. Права CI и runtime выдаются на конкретные ресурсы:
+
+```bash
+export CI_SA_ID=$(yc iam service-account get --name zvenfit-ci-sa --format json | jq -r '.id')
+
+yc ydb database create \
+  --name zvenfit-leads \
+  --description="Durable ZvenFit website leads" \
+  --serverless \
+  --sls-storage-size=1GB \
+  --deletion-protection
+
+yc iam service-account create \
+  --name zvenfit-lead-runtime \
+  --description="Runtime identity for ZvenFit durable lead delivery"
+export RUNTIME_SA_ID=$(yc iam service-account get --name zvenfit-lead-runtime --format json | jq -r '.id')
+
+yc ydb database add-access-binding \
+  --name zvenfit-leads \
+  --role ydb.editor \
+  --service-account-id $CI_SA_ID
+
+yc ydb database add-access-binding \
+  --name zvenfit-leads \
+  --role ydb.editor \
+  --service-account-id $RUNTIME_SA_ID
+
+yc iam service-account add-access-binding \
+  --id $RUNTIME_SA_ID \
+  --role iam.serviceAccounts.user \
+  --service-account-id $CI_SA_ID
+
+yc resource-manager folder add-access-binding \
+  --id $YC_FOLDER_ID \
+  --role monium.metrics.writer \
+  --service-account-id $RUNTIME_SA_ID
+
+yc serverless function create --name zvenfit-telegram-lead
+yc serverless function allow-unauthenticated-invoke zvenfit-telegram-lead
+yc serverless function add-access-binding \
+  --name zvenfit-telegram-lead \
+  --role functions.functionInvoker \
+  --service-account-id $RUNTIME_SA_ID
+
+yc serverless function create --name zvenfit-fitbase-schedule
+yc serverless function allow-unauthenticated-invoke zvenfit-fitbase-schedule
+```
+
+Публичный `functionInvoker` назначается один раз администратором. Обычный deploy
+только проверяет этот binding и поэтому CI не нуждается в `functions.admin`.
+
 Создай для этого SA API key со scope `yc.monium.metrics.write` и сохрани его
 secret-часть в GitHub Secret `MONIUM_API_KEY`. OTLP не принимает IAM-токен из
 контекста Cloud Function: заголовок должен иметь вид `Authorization: Api-Key …`.
@@ -144,7 +179,7 @@ git push origin main
 
 **Что произойдёт:**
 
-1. Workflow создаёт Serverless БД `zvenfit-leads`, если её ещё нет; включена защита от удаления.
+1. Workflow проверяет заранее созданную Serverless БД `zvenfit-leads` с защитой от удаления.
 2. Создаёт временные таблицы и прогоняет YDB integration test; production-таблица не меняется.
 3. До переключения функции применяет версионированные восстанавливаемые YDB-миграции из
    `functions/lead-intake/src/ydb/migrations.ts`.
@@ -298,8 +333,10 @@ curl "https://api.telegram.org/bot$TELEGRAM_BOT_TOKEN/sendMessage" \
 **deploy-function:**
 
 - `Authentication failed` → проверь `YC_SA_JSON_KEY` (валидный JSON?)
-- ошибка создания YDB → роль `ydb.editor` на CI SA
-- ошибка создания timer trigger → `functions.admin` у CI SA и `functions.functionInvoker` у runtime SA
+- `YDB database ... must be provisioned` → создай БД один раз и выдай CI `ydb.editor` на эту БД
+- ошибка YDB integration test или migration → проверь `ydb.editor` у CI на базе `zvenfit-leads`
+- ошибка создания timer trigger → `functions.editor` у CI и `functions.functionInvoker` у runtime SA
+- `missing the one-time public functionInvoker binding` → один раз выполни указанную команду под администратором
 - функция отвечает `storage_unavailable` → runtime SA не имеет `ydb.editor` или неверен endpoint БД
 - `Failed to get function URL` → функция создалась? Проверь в консоли YC
 

--- a/scripts/__tests__/deploy-lead-intake.test.cjs
+++ b/scripts/__tests__/deploy-lead-intake.test.cjs
@@ -28,6 +28,16 @@ test('production deploy jobs wait for quality checks', () => {
   assert.match(workflow.slice(scheduleDeployJob, siteDeployJob), /needs: quality-checks/);
 });
 
+test('every production deploy job is protected by the production environment', () => {
+  const leadDeployJob = workflow.indexOf('  deploy-function:');
+  const scheduleDeployJob = workflow.indexOf('  deploy-schedule-function:');
+  const siteDeployJob = workflow.indexOf('  deploy-site:');
+
+  assert.match(workflow.slice(leadDeployJob, scheduleDeployJob), /environment: production/);
+  assert.match(workflow.slice(scheduleDeployJob, siteDeployJob), /environment: production/);
+  assert.match(workflow.slice(siteDeployJob), /environment: production/);
+});
+
 test('lead deploy verifies YDB, migrates schema, and only then creates a function version', () => {
   const integration = deployScript.indexOf('run test:integration');
   const migration = deployScript.indexOf('run migrate');

--- a/scripts/__tests__/deploy-lead-intake.test.cjs
+++ b/scripts/__tests__/deploy-lead-intake.test.cjs
@@ -7,6 +7,7 @@ const test = require('node:test');
 
 const ROOT = path.resolve(__dirname, '../..');
 const deployScript = fs.readFileSync(path.join(ROOT, 'scripts/deploy-lead-intake.sh'), 'utf8');
+const scheduleDeployScript = fs.readFileSync(path.join(ROOT, 'scripts/deploy-fitbase-schedule.sh'), 'utf8');
 const workflow = fs.readFileSync(path.join(ROOT, '.github/workflows/main.yml'), 'utf8');
 
 test('lead deploy keeps the existing production Cloud Function resource', () => {
@@ -52,4 +53,17 @@ test('existing retry trigger is updated by resolved id', () => {
   assert.match(deployScript, /TRIGGER_ID=.*serverless trigger get/);
   assert.match(deployScript, /serverless trigger update timer[\s\\]+--id="\$\{TRIGGER_ID\}"/);
   assert.doesNotMatch(deployScript, /serverless trigger update timer[\s\\]+--name=/);
+});
+
+test('regular deploy verifies public access without mutating function IAM', () => {
+  for (const script of [deployScript, scheduleDeployScript]) {
+    assert.match(script, /serverless function list-access-bindings/);
+    assert.match(script, /missing the one-time public functionInvoker binding/);
+    assert.doesNotMatch(script, /^yc serverless function allow-unauthenticated-invoke/m);
+  }
+});
+
+test('regular deploy requires a pre-provisioned database', () => {
+  assert.match(deployScript, /must be provisioned before CI deploy/);
+  assert.doesNotMatch(deployScript, /^\s*yc ydb database create/m);
 });

--- a/scripts/deploy-fitbase-schedule.sh
+++ b/scripts/deploy-fitbase-schedule.sh
@@ -43,6 +43,21 @@ if ! yc serverless function get --name="${FUNCTION_NAME}" >/dev/null 2>&1; then
   yc serverless function create --name="${FUNCTION_NAME}"
 fi
 
+if ! yc serverless function list-access-bindings --name="${FUNCTION_NAME}" --format=json | node -e "
+const fs = require('fs');
+const bindings = JSON.parse(fs.readFileSync(0, 'utf8'));
+const publicInvoker = bindings.some(binding =>
+  binding.role_id === 'functions.functionInvoker' &&
+  binding.subject?.type === 'system' &&
+  binding.subject?.id === 'allUsers'
+);
+process.exit(publicInvoker ? 0 : 1);
+"; then
+  echo "deploy-fitbase-schedule: ${FUNCTION_NAME} is missing the one-time public functionInvoker binding" >&2
+  echo "Run with an admin identity: yc serverless function allow-unauthenticated-invoke ${FUNCTION_NAME}" >&2
+  exit 1
+fi
+
 ENV_ARGS=(
   --environment "FITBASE_API_TOKEN=${FITBASE_API_TOKEN}"
   --environment "FITBASE_DOMAIN=${FITBASE_DOMAIN}"
@@ -63,8 +78,6 @@ yc serverless function version create \
   --execution-timeout="${TIMEOUT}" \
   --source-path="${SOURCE_DIR}" \
   "${ENV_ARGS[@]}"
-
-yc serverless function allow-unauthenticated-invoke "${FUNCTION_NAME}"
 
 INVOKE_URL="$(yc serverless function get --name="${FUNCTION_NAME}" --format=json | node -e "
 const fs = require('fs');

--- a/scripts/deploy-lead-intake.sh
+++ b/scripts/deploy-lead-intake.sh
@@ -64,12 +64,8 @@ yc config set folder-id "${YC_FOLDER_ID}" >/dev/null
 
 if [[ -z "${YDB_CONNECTION_STRING:-}" ]]; then
   if ! yc ydb database get --name="${YDB_DATABASE_NAME}" >/dev/null 2>&1; then
-    yc ydb database create \
-      --name="${YDB_DATABASE_NAME}" \
-      --description="Durable ZvenFit website leads" \
-      --serverless \
-      --sls-storage-size=1GB \
-      --deletion-protection
+    echo "deploy-lead-intake: YDB database ${YDB_DATABASE_NAME} must be provisioned before CI deploy" >&2
+    exit 1
   fi
 
   YDB_CONNECTION_STRING="$(yc ydb database get --name="${YDB_DATABASE_NAME}" --format=json | node -e "
@@ -101,6 +97,21 @@ unset LEAD_YDB_IAM_TOKEN
 
 if ! yc serverless function get --name="${FUNCTION_NAME}" >/dev/null 2>&1; then
   yc serverless function create --name="${FUNCTION_NAME}"
+fi
+
+if ! yc serverless function list-access-bindings --name="${FUNCTION_NAME}" --format=json | node -e "
+const fs = require('fs');
+const bindings = JSON.parse(fs.readFileSync(0, 'utf8'));
+const publicInvoker = bindings.some(binding =>
+  binding.role_id === 'functions.functionInvoker' &&
+  binding.subject?.type === 'system' &&
+  binding.subject?.id === 'allUsers'
+);
+process.exit(publicInvoker ? 0 : 1);
+"; then
+  echo "deploy-lead-intake: ${FUNCTION_NAME} is missing the one-time public functionInvoker binding" >&2
+  echo "Run with an admin identity: yc serverless function allow-unauthenticated-invoke ${FUNCTION_NAME}" >&2
+  exit 1
 fi
 
 cp -R "${ROOT_DIR}/functions/lead-intake/build/." "${SOURCE_DIR}/"
@@ -142,8 +153,6 @@ yc serverless function version create \
   --environment MONIUM_METRICS_TIMEOUT_MS="${MONIUM_METRICS_TIMEOUT_MS}" \
   --environment LOG_LEVEL="${LOG_LEVEL}" \
   --environment NODE_ENV="${NODE_ENV:-production}"
-
-yc serverless function allow-unauthenticated-invoke "${FUNCTION_NAME}"
 
 if yc serverless trigger get --name="${TRIGGER_NAME}" >/dev/null 2>&1; then
   TRIGGER_ID="$(yc serverless trigger get --name="${TRIGGER_NAME}" --format=json | node -e "


### PR DESCRIPTION
## Что изменено
- CI больше не создаёт YDB и требует заранее подготовленную базу
- deploy проверяет public functionInvoker, но не изменяет IAM на каждом запуске
- документация переведена на resource-level YDB и runtime-SA bindings
- добавлены regression tests для least-privilege deploy

## Уже применено в Yandex Cloud
- CI ydb.editor перенесён на zvenfit-leads
- CI iam.serviceAccounts.user перенесён на zvenfit-lead-runtime
- runtime оставлен только monium.metrics.writer
- удалены ошибочные storage bindings на CI SA
- добавлен functions.editor; старый admin будет снят после merge

## Проверка
- npm run test:lead-import
- npm run lint:public
- bash -n scripts/deploy-lead-intake.sh scripts/deploy-fitbase-schedule.sh
- impersonation smoke для CI SA: YDB, function, trigger, production bucket