### PR TITLE
fix: stop false critical YDB latency alerts

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -11,15 +11,15 @@
 
 ## Текущая инфраструктура
 
-| Ресурс                  | Значение                       |
-| ----------------------- | ------------------------------ |
-| Monium project          | `folder__b1ge1e4iopttj79hfdfm` |
-| Cloud Logging group     | `default`                      |
-| Log cluster / service   | `default` / `default`          |
+| Ресурс                    | Значение                          |
+| ------------------------- | --------------------------------- |
+| Monium project            | `folder__b1ge1e4iopttj79hfdfm`    |
+| Cloud Logging group       | `default`                         |
+| Log cluster / service     | `default` / `default`             |
 | Application / environment | `zvenfit-frontend` / `production` |
-| Lead function           | `zvenfit-telegram-lead`        |
-| Schedule function       | `zvenfit-fitbase-schedule`     |
-| Cloud Logging retention | 3 days                         |
+| Lead function             | `zvenfit-telegram-lead`           |
+| Schedule function         | `zvenfit-fitbase-schedule`        |
+| Cloud Logging retention   | 3 days                            |
 
 Project dashboard: <https://monium.yandex.cloud/projects/folder__b1ge1e4iopttj79hfdfm/dashboards/zvenfit-production-monitoring>
 
@@ -43,21 +43,21 @@ Telegram username, UTM и тело ответа Fitbase в лог не попа�
 а известные поля с PII, телами запросов и секретами автоматически заменяются на
 `[REDACTED]`. Уровень можно менять переменной `LOG_LEVEL`, по умолчанию `info`.
 
-| Event                                  | Meaning                                             | Severity   |
-| -------------------------------------- | --------------------------------------------------- | ---------- |
-| `lead_storage_error`                   | Новую заявку не удалось сохранить в YDB             | Critical   |
-| `lead_submission_blocked`              | Honeypot, размер или rate limit отклонил отправку     | Diagnostic |
-| `lead_rate_limit_error`                | Rate limiter недоступен; заявка пропущена fail-open   | Warning    |
-| `lead_persisted`                       | Новая валидная заявка сохранена                       | Diagnostic |
-| `telegram_delivery_retry_error`        | Retry-задача не смогла обработать заявку            | Critical   |
-| `telegram_delivery_retry_scheduled`    | Telegram временно недоступен, будет retry           | Log only   |
-| `telegram_delivery_failed_permanently` | Исчерпаны попытки Telegram                          | Critical   |
-| `ydb_operation_completed`              | Длительность и число retry завершённой операции YDB | Diagnostic |
-| `ydb_retry`                            | YDB SDK повторил операцию после временной ошибки    | Warning    |
-| `ydb_slow_operation`                   | Операция YDB превысила `YDB_SLOW_OPERATION_MS`      | Warning    |
-| `ydb_operation_failed`                 | Операция YDB завершилась ошибкой                    | Critical   |
-| `fitbase_schedule_error`               | Fitbase вернул ошибку или недоступен                | Warning    |
-| `fitbase_schedule_misconfigured`       | В функции отсутствует Fitbase token                 | Critical   |
+| Event                                  | Meaning                                                      | Severity   |
+| -------------------------------------- | ------------------------------------------------------------ | ---------- |
+| `lead_storage_error`                   | Новую заявку не удалось сохранить в YDB                      | Critical   |
+| `lead_submission_blocked`              | Honeypot, размер или rate limit отклонил отправку            | Diagnostic |
+| `lead_rate_limit_error`                | Rate limiter недоступен; заявка пропущена fail-open          | Warning    |
+| `lead_persisted`                       | Новая валидная заявка сохранена                              | Diagnostic |
+| `telegram_delivery_retry_error`        | Retry-задача не смогла обработать заявку                     | Critical   |
+| `telegram_delivery_retry_scheduled`    | Telegram временно недоступен, будет retry                    | Log only   |
+| `telegram_delivery_failed_permanently` | Исчерпаны попытки Telegram                                   | Critical   |
+| `ydb_operation_completed`              | Длительность SQL-операции и число retry, без запуска клиента | Diagnostic |
+| `ydb_retry`                            | YDB SDK повторил операцию после временной ошибки             | Warning    |
+| `ydb_slow_operation`                   | Операция YDB превысила `YDB_SLOW_OPERATION_MS`               | Warning    |
+| `ydb_operation_failed`                 | Операция YDB завершилась ошибкой                             | Critical   |
+| `fitbase_schedule_error`               | Fitbase вернул ошибку или недоступен                         | Warning    |
+| `fitbase_schedule_misconfigured`       | В функции отсутствует Fitbase token                          | Critical   |
 
 ## Метрики по логам
 
@@ -169,21 +169,30 @@ Telegram username, UTM и тело ответа Fitbase в лог не попа�
 OTLP-метрики приложения, два runtime-сигнала — автоматическую метрику Cloud
 Functions, storage alert — две автоматические метрики YDB:
 
-| Alert ID                          | Metric / signal                          | Function | Warning | Alarm   | Window | Delay | No data |
-| --------------------------------- | ---------------------------------------- | -------- | ------: | ------: | -----: | ----: | ------- |
-| `zvenfit_lead_storage_errors`     | direct `zvenfit_lead_storage_errors`     | `max`    |   `> 0` |  `> 0.5` |     5m |   30s | OK      |
-| `zvenfit_permanent_telegram_failures` | direct `zvenfit_telegram_delivery_failed_1m` | `max` |   `> 0` |  `> 0.5` |     5m |   30s | OK      |
-| `zvenfit_fitbase_errors`          | `functions_errors`, schedule only        | `max`    |   `> 0` |  `> 0.5` |    10m |   30s | OK      |
-| `zvenfit_function_runtime_errors` | `functions_errors` for both function names | `sum`  |   `> 0` |  `> 0.5` |     5m |   30s | OK      |
-| `zvenfit_ydb_retries`             | direct `zvenfit_ydb_retries_5m`          | `sum`    | `> 4.5` |  `> 5.5` |    10m |   30s | OK      |
-| `zvenfit_slow_ydb_operations`     | direct `zvenfit_ydb_slow_operations_5m`  | `sum`    |   `> 0` |  `> 0.5` |    10m |   30s | OK      |
-| `zvenfit_rate-limited_leads`      | direct `zvenfit_lead_rate_limited_5m`    | `sum`    |   `> 0` |    `> 5` |    10m |   30s | OK      |
-| `zvenfit_persisted_leads_volume`  | direct `zvenfit_leads_persisted_5m`      | `sum`    |  `> 10` |   `> 20` |    10m |   30s | OK      |
-| `zvenfit_ydb_storage_usage`       | query `C`, storage used percent           | `last`   | `>= 70` | `>= 85` |    15m |   30s | Warning |
+| Alert ID                              | Metric / signal                              | Function | Warning |   Alarm | Window | Delay | No data |
+| ------------------------------------- | -------------------------------------------- | -------- | ------: | ------: | -----: | ----: | ------- |
+| `zvenfit_lead_storage_errors`         | direct `zvenfit_lead_storage_errors`         | `max`    |   `> 0` | `> 0.5` |     5m |   30s | OK      |
+| `zvenfit_permanent_telegram_failures` | direct `zvenfit_telegram_delivery_failed_1m` | `max`    |   `> 0` | `> 0.5` |     5m |   30s | OK      |
+| `zvenfit_fitbase_errors`              | `functions_errors`, schedule only            | `max`    |   `> 0` | `> 0.5` |    10m |   30s | OK      |
+| `zvenfit_function_runtime_errors`     | `functions_errors` for both function names   | `sum`    |   `> 0` | `> 0.5` |     5m |   30s | OK      |
+| `zvenfit_ydb_retries`                 | direct `zvenfit_ydb_retries_5m`              | `sum`    | `> 4.5` | `> 5.5` |    10m |   30s | OK      |
+| `zvenfit_slow_ydb_operations`         | direct `zvenfit_ydb_slow_operations_5m`      | `sum`    | `> 0.5` | `> 2.5` |    10m |   30s | OK      |
+| `zvenfit_rate-limited_leads`          | direct `zvenfit_lead_rate_limited_5m`        | `sum`    |   `> 0` |   `> 5` |    10m |   30s | OK      |
+| `zvenfit_persisted_leads_volume`      | direct `zvenfit_leads_persisted_5m`          | `sum`    |  `> 10` |  `> 20` |    10m |   30s | OK      |
+| `zvenfit_ydb_storage_usage`           | query `C`, storage used percent              | `last`   | `>= 70` | `>= 85` |    15m |   30s | Warning |
 
 Monium требует `Alarm > Warning`. Для целочисленных счётчиков промежуточное
-значение `0.5` техническое: любая первая точка со значением `1` сразу получает
-статус `Alarm`. Прямые и platform metrics используют задержку вычисления `30s`.
+значение `0.5` техническое. Для error counters первая точка со значением `1`
+сразу даёт `Alarm`; для slow YDB пороги намеренно разведены: единичное превышение
+даёт `Warning`, а `Alarm` требует минимум три превышения за 10 минут. Прямые и
+platform metrics используют задержку вычисления `30s`.
+
+Приложение экспортирует event counters с `DELTA` temporality. Каждая инвокация
+serverless-функции создаёт отдельный одноразовый MeterProvider, поэтому
+`CUMULATIVE` сбрасывал бы одну и ту же временную серию обратно в `1`. Latency
+операции измеряется после готовности YDB-клиента, чтобы холодное создание driver
+не выглядело как медленный SQL-запрос. Порог `YDB_SLOW_OPERATION_MS` относится
+именно к выполнению операции после инициализации клиента.
 
 Селектор прямой метрики ошибки сохранения:
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -74,16 +74,16 @@ rm sa-key.json
 
 **Settings → Secrets and variables → Actions:**
 
-| Secret                 | Откуда                     | Пример                                     |
-| ---------------------- | -------------------------- | ------------------------------------------ |
-| `YC_SA_JSON_KEY`       | `sa-key.json` целиком      | `{"id":"aje...","service_account_id":...}` |
-| `YC_FOLDER_ID`         | `yc config get folder-id`  | `b1g...`                                   |
-| `TELEGRAM_BOT_TOKEN`   | @BotFather                 | `123456:ABC...`                            |
-| `TELEGRAM_CHAT_ID`     | getUpdates                 | `-5161525132`                              |
-| `LEAD_RATE_LIMIT_SECRET` | `openssl rand -hex 32`    | Случайная строка для HMAC IP               |
-| `MONIUM_API_KEY`        | Scoped API key runtime SA | OTLP-запись метрик в Monium                 |
-| `YC_ACCESS_KEY_ID`     | Статический ключ SA для S3 | Уже есть                                   |
-| `YC_SECRET_ACCESS_KEY` | Пара к `ACCESS_KEY_ID`     | Уже есть                                   |
+| Secret                   | Откуда                     | Пример                                     |
+| ------------------------ | -------------------------- | ------------------------------------------ |
+| `YC_SA_JSON_KEY`         | `sa-key.json` целиком      | `{"id":"aje...","service_account_id":...}` |
+| `YC_FOLDER_ID`           | `yc config get folder-id`  | `b1g...`                                   |
+| `TELEGRAM_BOT_TOKEN`     | @BotFather                 | `123456:ABC...`                            |
+| `TELEGRAM_CHAT_ID`       | getUpdates                 | `-5161525132`                              |
+| `LEAD_RATE_LIMIT_SECRET` | `openssl rand -hex 32`     | Случайная строка для HMAC IP               |
+| `MONIUM_API_KEY`         | Scoped API key runtime SA  | OTLP-запись метрик в Monium                |
+| `YC_ACCESS_KEY_ID`       | Статический ключ SA для S3 | Уже есть                                   |
+| `YC_SECRET_ACCESS_KEY`   | Пара к `ACCESS_KEY_ID`     | Уже есть                                   |
 
 Обязательная GitHub Variable:
 
@@ -93,23 +93,23 @@ rm sa-key.json
 
 Опциональные GitHub Variables:
 
-| Variable                | Default         | Что меняет                                                                |
-| ----------------------- | --------------- | ------------------------------------------------------------------------- |
-| `YDB_DATABASE_NAME`     | `zvenfit-leads` | Имя Serverless БД                                                         |
-| `YDB_LEADS_TABLE`       | `leads`         | Таблица заявок                                                            |
-| `YDB_RATE_LIMITS_TABLE` | `lead_rate_limits` | Технические счётчики ограничения частоты                              |
-| `LEAD_RATE_LIMIT_MAX`   | `5`             | Допустимых заявок с одного IP за окно                                     |
-| `LEAD_RATE_LIMIT_WINDOW_SECONDS` | `600` | Размер окна ограничения частоты                                        |
-| `MAX_TELEGRAM_ATTEMPTS` | `12`            | После скольких попыток поставить статус `failed`                          |
-| `YDB_QUERY_TIMEOUT_MS`  | `5000`          | Клиентский таймаут операции/транзакции YDB                                |
-| `YDB_SLOW_OPERATION_MS` | `1000`          | Порог события `ydb_slow_operation`                                        |
-| `YDB_SESSION_POOL_SIZE` | `5`             | Максимум YDB-сессий на экземпляр функции                                  |
-| `MONIUM_METRICS_ENABLED` | `true`         | Включает прямую отправку метрик функции по OTLP                            |
-| `MONIUM_PROJECT`        | `folder__<YC_FOLDER_ID>` | Проект Monium; локальный deploy выводит его из folder ID          |
-| `MONIUM_CLUSTER`        | `default`       | Кластер прямых метрик                                                      |
-| `MONIUM_SERVICE`        | `zvenfit-frontend` | Сервис прямых метрик                                                    |
-| `MONIUM_METRICS_TIMEOUT_MS` | `1000`     | Максимальное ожидание отправки метрик в конце вызова                       |
-| `NODE_ENV`              | `production`    | Значение поля `environment` в structured logs функций                     |
+| Variable                         | Default                  | Что меняет                                                                 |
+| -------------------------------- | ------------------------ | -------------------------------------------------------------------------- |
+| `YDB_DATABASE_NAME`              | `zvenfit-leads`          | Имя Serverless БД                                                          |
+| `YDB_LEADS_TABLE`                | `leads`                  | Таблица заявок                                                             |
+| `YDB_RATE_LIMITS_TABLE`          | `lead_rate_limits`       | Технические счётчики ограничения частоты                                   |
+| `LEAD_RATE_LIMIT_MAX`            | `5`                      | Допустимых заявок с одного IP за окно                                      |
+| `LEAD_RATE_LIMIT_WINDOW_SECONDS` | `600`                    | Размер окна ограничения частоты                                            |
+| `MAX_TELEGRAM_ATTEMPTS`          | `12`                     | После скольких попыток поставить статус `failed`                           |
+| `YDB_QUERY_TIMEOUT_MS`           | `5000`                   | Клиентский таймаут операции/транзакции YDB                                 |
+| `YDB_SLOW_OPERATION_MS`          | `1000`                   | Порог SQL-операции `ydb_slow_operation`, без холодного запуска YDB-клиента |
+| `YDB_SESSION_POOL_SIZE`          | `5`                      | Максимум YDB-сессий на экземпляр функции                                   |
+| `MONIUM_METRICS_ENABLED`         | `true`                   | Включает прямую отправку метрик функции по OTLP                            |
+| `MONIUM_PROJECT`                 | `folder__<YC_FOLDER_ID>` | Проект Monium; локальный deploy выводит его из folder ID                   |
+| `MONIUM_CLUSTER`                 | `default`                | Кластер прямых метрик                                                      |
+| `MONIUM_SERVICE`                 | `zvenfit-frontend`       | Сервис прямых метрик                                                       |
+| `MONIUM_METRICS_TIMEOUT_MS`      | `1000`                   | Максимальное ожидание отправки метрик в конце вызова                       |
+| `NODE_ENV`                       | `production`             | Значение поля `environment` в structured logs функций                      |
 
 До первого CI deploy создай YDB, обе функции и отдельный runtime SA под учётной
 записью администратора. Права CI и runtime выдаются на конкретные ресурсы:

--- a/functions/lead-intake/src/observability/__tests__/metrics.test.ts
+++ b/functions/lead-intake/src/observability/__tests__/metrics.test.ts
@@ -207,7 +207,7 @@ test('collects once and waits for the exporter callback before shutdown', async 
     .flatMap(scope => scope.metrics)
     .find(item => item.descriptor.name === 'zvenfit_test_events');
   assert.ok(metric);
-  assert.equal(metric.aggregationTemporality, AggregationTemporality.CUMULATIVE);
+  assert.equal(metric.aggregationTemporality, AggregationTemporality.DELTA);
   assert.equal(metric.dataPoints[0]?.value, 2);
   assert.deepEqual(metric.dataPoints[0]?.attributes, { outcome: 'stored' });
 });

--- a/functions/lead-intake/src/observability/__tests__/ydb.test.ts
+++ b/functions/lead-intake/src/observability/__tests__/ydb.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { channel } from 'node:diagnostics_channel';
 import test from 'node:test';
 
-import { observeYdbOperation } from '../ydb';
+import { observeYdbOperation, prepareAndObserveYdbOperation } from '../ydb';
 
 import type { JsonObject, LoggerLike } from '../../types';
 
@@ -55,4 +55,38 @@ test('logs a safe error code without the database error message', async () => {
   const failure = recordByEvent(logger.records, 'ydb_operation_failed');
   assert.equal(failure.error_code, 'OVERLOADED');
   assert.equal(JSON.stringify(failure).includes('phone number'), false);
+});
+
+test('excludes client preparation from operation latency', async () => {
+  const logger = memoryLogger();
+  const originalNow = Date.now;
+  let now = 1_000;
+  Date.now = () => now;
+
+  try {
+    const result = await prepareAndObserveYdbOperation(
+      'list_telegram_candidates',
+      logger,
+      async () => {
+        now += 2_000;
+
+        return 'ready-client';
+      },
+      async client => {
+        assert.equal(client, 'ready-client');
+        now += 50;
+
+        return 'ok';
+      },
+    );
+
+    assert.equal(result, 'ok');
+    assert.equal(recordByEvent(logger.records, 'ydb_operation_completed').duration_ms, 50);
+    assert.equal(
+      logger.records.some(record => record.event === 'ydb_slow_operation'),
+      false,
+    );
+  } finally {
+    Date.now = originalNow;
+  }
 });

--- a/functions/lead-intake/src/observability/otel-transport.ts
+++ b/functions/lead-intake/src/observability/otel-transport.ts
@@ -167,7 +167,10 @@ function createOtelExporter(options: MetricsTransportOptions): PushMetricExporte
     url: options.endpoint,
     headers: options.headers,
     timeoutMillis: options.timeoutMs,
-    temporalityPreference: AggregationTemporality.CUMULATIVE,
+    // Each Cloud Function invocation owns a one-shot meter provider. DELTA
+    // preserves event counts across those short-lived providers; CUMULATIVE
+    // made every invocation restart the same series at 1.
+    temporalityPreference: AggregationTemporality.DELTA,
   });
 }
 
@@ -177,7 +180,7 @@ export function createOtelTransport(
 ): MetricsTransport {
   const exporter = exporterFactory(options);
   const reader = new OneShotMetricReader({
-    aggregationTemporalitySelector: () => AggregationTemporality.CUMULATIVE,
+    aggregationTemporalitySelector: () => AggregationTemporality.DELTA,
   });
   const provider = new MeterProvider({ readers: [reader] });
 

--- a/functions/lead-intake/src/observability/ydb.ts
+++ b/functions/lead-intake/src/observability/ydb.ts
@@ -97,6 +97,17 @@ export async function observeYdbOperation<T>(
   }
 }
 
+export async function prepareAndObserveYdbOperation<TPrepared, TResult>(
+  operationName: string,
+  logger: LoggerLike | undefined,
+  prepare: () => Promise<TPrepared>,
+  callback: (prepared: TPrepared) => Promise<TResult>,
+): Promise<TResult> {
+  const prepared = await prepare();
+
+  return observeYdbOperation(operationName, logger, () => callback(prepared));
+}
+
 export const _private = {
   errorCode,
   subscribeToRetries,

--- a/functions/lead-intake/src/ydb/context.ts
+++ b/functions/lead-intake/src/ydb/context.ts
@@ -1,6 +1,6 @@
 import { createYdbClient } from './client';
 import { queryTimeoutMs } from './config';
-import { observeYdbOperation } from '../observability/ydb';
+import { prepareAndObserveYdbOperation } from '../observability/ydb';
 
 import type { ClaimedLead, LoggerLike, SqlRow, TelegramStatus, YdbClient, YdbQuery, YdbValue } from '../types';
 
@@ -37,8 +37,16 @@ export function timed<T>(query: YdbQuery<T>): YdbQuery<T> {
   return query.timeout(queryTimeoutMs());
 }
 
-export function observed<T>(operation: string, logger: LoggerLike | undefined, callback: () => Promise<T>): Promise<T> {
-  return observeYdbOperation(operation, logger, callback);
+export async function observed<T>(
+  operation: string,
+  logger: LoggerLike | undefined,
+  callback: (sql: YdbClient['sql']) => Promise<T>,
+): Promise<T> {
+  // Establishing a YDB driver can take a couple of seconds in a cold
+  // serverless container. Keep that startup cost out of the SQL-operation
+  // latency signal; otherwise the retry timer reports a slow query whenever
+  // Yandex Cloud gives it a fresh container.
+  return prepareAndObserveYdbOperation(operation, logger, getSql, callback);
 }
 
 export function firstResultSet(resultSets: unknown): SqlRow[] {

--- a/functions/lead-intake/src/ydb/lead-persistence.ts
+++ b/functions/lead-intake/src/ydb/lead-persistence.ts
@@ -1,13 +1,5 @@
 import { tableName } from './config';
-import {
-  getSql,
-  firstResultSet,
-  observed,
-  telegramStatus,
-  transactionOptions,
-  ydbTimestamp,
-  ydbUint32,
-} from './context';
+import { firstResultSet, observed, telegramStatus, transactionOptions, ydbTimestamp, ydbUint32 } from './context';
 
 import type { Lead, LoggerLike, TelegramStatus } from '../types';
 
@@ -15,8 +7,7 @@ export async function saveLead(
   lead: Lead,
   { logger }: { logger?: LoggerLike } = {},
 ): Promise<{ created: boolean; telegramStatus: TelegramStatus }> {
-  return observed('save_lead', logger, async () => {
-    const sql = await getSql();
+  return observed('save_lead', logger, async sql => {
     const leadsTable = sql.identifier(tableName());
 
     return sql.begin(transactionOptions(), async tx => {
@@ -70,8 +61,7 @@ export async function importDeliveredLead(
   lead: Lead & { notifiedAt?: Date },
   { logger }: { logger?: LoggerLike } = {},
 ): Promise<{ created: boolean; telegramStatus: TelegramStatus }> {
-  return observed('import_delivered_lead', logger, async () => {
-    const sql = await getSql();
+  return observed('import_delivered_lead', logger, async sql => {
     const leadsTable = sql.identifier(tableName());
 
     return sql.begin(transactionOptions(), async tx => {

--- a/functions/lead-intake/src/ydb/rate-limit.ts
+++ b/functions/lead-intake/src/ydb/rate-limit.ts
@@ -1,7 +1,7 @@
 import { createHmac } from 'node:crypto';
 
 import { parsePositiveInt, rateLimitsTableName } from './config';
-import { firstResultSet, getSql, observed, transactionOptions, ydbTimestamp, ydbUint32 } from './context';
+import { firstResultSet, observed, transactionOptions, ydbTimestamp, ydbUint32 } from './context';
 
 import type { LoggerLike } from '../types';
 
@@ -52,9 +52,8 @@ export async function consumeLeadRateLimit({
   now: Date;
   logger?: LoggerLike;
 }): Promise<boolean> {
-  return observed('lead_rate_limit', logger, async () => {
+  return observed('lead_rate_limit', logger, async sql => {
     const { maxRequests, windowSeconds, secret } = settings();
-    const sql = await getSql();
     const rateLimitsTable = sql.identifier(rateLimitsTableName());
     const key = rateKey(sourceIp, now, windowSeconds, secret);
     const expiresAt = new Date(windowStart(now, windowSeconds) + COUNTER_RETENTION_MS);

--- a/functions/lead-intake/src/ydb/telegram-queue.ts
+++ b/functions/lead-intake/src/ydb/telegram-queue.ts
@@ -1,7 +1,6 @@
 import { dueIndexName, tableName } from './config';
 import {
   firstResultSet,
-  getSql,
   observed,
   rowToLead,
   stringValue,
@@ -27,8 +26,7 @@ export async function claimForTelegram({
   deliveryToken: string;
   logger?: LoggerLike;
 }): Promise<ClaimedLead | null> {
-  return observed('claim_for_telegram', logger, async () => {
-    const sql = await getSql();
+  return observed('claim_for_telegram', logger, async sql => {
     const leadsTable = sql.identifier(tableName());
 
     return sql.begin(transactionOptions(), async tx => {
@@ -90,8 +88,7 @@ export async function markTelegramDelivered({
   notifiedAt: Date;
   logger?: LoggerLike;
 }): Promise<void> {
-  return observed('mark_telegram_delivered', logger, async () => {
-    const sql = await getSql();
+  return observed('mark_telegram_delivered', logger, async sql => {
     const leadsTable = sql.identifier(tableName());
     await timed(
       sql`
@@ -126,8 +123,7 @@ export async function markTelegramFailed({
   terminal: boolean;
   logger?: LoggerLike;
 }): Promise<void> {
-  return observed('mark_telegram_failed', logger, async () => {
-    const sql = await getSql();
+  return observed('mark_telegram_failed', logger, async sql => {
     const leadsTable = sql.identifier(tableName());
     const status = terminal ? 'failed' : 'pending';
     const dueAt = terminal ? sql.fragment`NULL` : sql.fragment`${ydbTimestamp(failedAt)}`;
@@ -158,8 +154,7 @@ export async function listTelegramCandidates({
   limit: number;
   logger?: LoggerLike;
 }): Promise<string[]> {
-  return observed('list_telegram_candidates', logger, async () => {
-    const sql = await getSql();
+  return observed('list_telegram_candidates', logger, async sql => {
     const leadsTable = sql.identifier(tableName());
     const dueIndex = sql.identifier(dueIndexName());
     const safeLimit = Math.min(Math.max(Number(limit) || 1, 1), 100);

--- a/scripts/__tests__/monitoring-config.test.cjs
+++ b/scripts/__tests__/monitoring-config.test.cjs
@@ -37,7 +37,11 @@ test('every alert references a metric and is documented', () => {
     const hasPlatformMetric = typeof alert.metricSelector === 'string';
     const hasMetricQueries = Array.isArray(alert.queries) && alert.queries.length > 0;
 
-    assert.equal(Boolean(hasLogMetric || hasPlatformMetric || hasMetricQueries), true, `${alert.id} references an unknown metric`);
+    assert.equal(
+      Boolean(hasLogMetric || hasPlatformMetric || hasMetricQueries),
+      true,
+      `${alert.id} references an unknown metric`,
+    );
     assert.equal(alertIds.has(alert.id), false, `${alert.id} is duplicated`);
     assert.match(monitoringDocs, new RegExp(`\\b${alert.id}\\b`), `${alert.id} is missing from docs`);
     assert.equal(alert.noData, alert.id === 'zvenfit_ydb_storage_usage' ? 'WARNING' : 'OK');
@@ -81,6 +85,23 @@ test('YDB retry thresholds expose reachable Warning and Alarm states', () => {
     { warning: alert.warning, alarm: alert.alarm, operator: alert.operator },
     { warning: 4.5, alarm: 5.5, operator: '>' },
   );
+});
+
+test('slow YDB alert warns on one event and alarms on three events in ten minutes', () => {
+  const alert = config.alerts.find(item => item.id === 'zvenfit_slow_ydb_operations');
+
+  assert.deepEqual(
+    {
+      warning: alert.warning,
+      alarm: alert.alarm,
+      aggregation: alert.aggregation,
+      operator: alert.operator,
+      window: alert.window,
+    },
+    { warning: 0.5, alarm: 2.5, aggregation: 'sum', operator: '>', window: '10m' },
+  );
+  assert.match(monitoringDocs, /единичное превышение\s+даёт `Warning`/);
+  assert.match(monitoringDocs, /`Alarm` требует минимум три превышения за 10 минут/);
 });
 
 test('YDB storage alert uses live database metrics and 70/85 percent thresholds', () => {

--- a/scripts/monitoring.config.json
+++ b/scripts/monitoring.config.json
@@ -145,8 +145,8 @@
       "metricSelector": "{project=\"folder__b1ge1e4iopttj79hfdfm\", cluster=\"default\", service=\"zvenfit-frontend\", name=\"zvenfit_ydb_slow_operations_5m\"}",
       "aggregation": "sum",
       "operator": ">",
-      "warning": 0,
-      "alarm": 0.5,
+      "warning": 0.5,
+      "alarm": 2.5,
       "window": "10m",
       "delay": "30s",
       "noData": "OK"


### PR DESCRIPTION
Separates cold YDB client initialization from SQL latency, exports one-shot OTLP counters with DELTA temporality, and changes the slow-operation alert to Warning on one event and Alarm on three events in ten minutes. Verified with lead-function tests, monitoring contract tests, lint, formatting, and the static production build.