### PR TITLE
chore: enforce project branch naming

### DIFF
--- a/.cursor/rules/git-branch-naming.mdc
+++ b/.cursor/rules/git-branch-naming.mdc
@@ -1,0 +1,14 @@
+---
+description: Git branch naming conventions for ZvenFit
+alwaysApply: true
+---
+
+# Git Branch Naming
+
+- Do not use the `codex/` prefix.
+- Choose a semantic prefix that matches the work:
+  - `feature/` for new functionality.
+  - `bugfix/` for ordinary defect fixes.
+  - `hotfix/` for urgent production fixes.
+  - `chore/`, `docs/`, or `refactor/` when those categories fit better.
+- Keep the remainder short, lowercase, and kebab-case, for example `bugfix/telegram-ipv4`.


### PR DESCRIPTION
Adds an always-on project Codex rule that prohibits the codex prefix and requires semantic branch prefixes such as feature, bugfix, hotfix, chore, docs, or refactor.