### PR TITLE
fix: enforce strict concurrent lead rate limit

### DIFF
--- a/functions/lead-intake/src/ydb/__tests__/integration/lead-store.test.ts
+++ b/functions/lead-intake/src/ydb/__tests__/integration/lead-store.test.ts
@@ -73,13 +73,18 @@ test(
       assert.deepEqual(await runMigrations({ log: { info() {} } }), [1]);
       assert.deepEqual(await runMigrations({ log: { info() {} } }), []);
 
-      const rateLimitResults = await Promise.all(
-        Array.from({ length: 6 }, () =>
-          consumeLeadRateLimit({ sourceIp: '203.0.113.10', now: new Date('2026-08-10T10:01:00.000Z') }),
-        ),
-      );
-      assert.equal(rateLimitResults.filter(Boolean).length, 5);
-      assert.equal(rateLimitResults.filter(result => !result).length, 1);
+      for (let round = 0; round < 5; round += 1) {
+        const rateLimitResults = await Promise.all(
+          Array.from({ length: 10 }, () =>
+            consumeLeadRateLimit({
+              sourceIp: `203.0.113.${10 + round}`,
+              now: new Date('2026-08-10T10:01:00.000Z'),
+            }),
+          ),
+        );
+        assert.equal(rateLimitResults.filter(Boolean).length, 5);
+        assert.equal(rateLimitResults.filter(result => !result).length, 5);
+      }
 
       const now = new Date();
       const leadId = randomUUID();

--- a/functions/lead-intake/src/ydb/__tests__/rate-limit.test.ts
+++ b/functions/lead-intake/src/ydb/__tests__/rate-limit.test.ts
@@ -15,6 +15,12 @@ test('rate-limit key is stable inside a window and never contains the source IP'
   assert.doesNotMatch(first, /203\.0\.113\.10/);
 });
 
+test('only a duplicate-key precondition error marks a rate-limit slot as occupied', () => {
+  assert.equal(_private.isOccupiedSlotError({ code: 400120 }), true);
+  assert.equal(_private.isOccupiedSlotError({ code: 400090 }), false);
+  assert.equal(_private.isOccupiedSlotError(new Error('PRECONDITION_FAILED')), false);
+});
+
 test('rate-limit settings use safe defaults and require a secret', () => {
   const originalSecret = process.env.LEAD_RATE_LIMIT_SECRET;
   const originalMax = process.env.LEAD_RATE_LIMIT_MAX;

--- a/functions/lead-intake/src/ydb/rate-limit.ts
+++ b/functions/lead-intake/src/ydb/rate-limit.ts
@@ -1,7 +1,7 @@
 import { createHmac } from 'node:crypto';
 
 import { parsePositiveInt, rateLimitsTableName } from './config';
-import { firstResultSet, observed, transactionOptions, ydbTimestamp, ydbUint32 } from './context';
+import { observed, timed, ydbTimestamp, ydbUint32 } from './context';
 
 import type { LoggerLike } from '../types';
 
@@ -11,6 +11,7 @@ const MIN_SECRET_LENGTH = 32;
 const MAX_CONFIGURED_REQUESTS = 1000;
 const MAX_WINDOW_SECONDS = 24 * 60 * 60;
 const COUNTER_RETENTION_MS = 24 * 60 * 60 * 1000;
+const YDB_PRECONDITION_FAILED = 400120;
 
 function settings(): { maxRequests: number; windowSeconds: number; secret: string } {
   const secret = (process.env.LEAD_RATE_LIMIT_SECRET || '').trim();
@@ -43,6 +44,10 @@ function rateKey(sourceIp: string, now: Date, windowSeconds: number, secret: str
   return `${ipDigest}:${windowStart(now, windowSeconds)}`;
 }
 
+function isOccupiedSlotError(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'code' in error && error.code === YDB_PRECONDITION_FAILED;
+}
+
 export async function consumeLeadRateLimit({
   sourceIp,
   now,
@@ -57,42 +62,28 @@ export async function consumeLeadRateLimit({
     const rateLimitsTable = sql.identifier(rateLimitsTableName());
     const key = rateKey(sourceIp, now, windowSeconds, secret);
     const expiresAt = new Date(windowStart(now, windowSeconds) + COUNTER_RETENTION_MS);
-    const maxRequestsValue = ydbUint32(maxRequests);
+    // A counter update can lose the predicate race under concurrent YDB
+    // transactions: multiple callers may all observe request_count < max and
+    // report success. Model the limit as maxRequests unique primary-key slots
+    // instead. INSERT is the atomic arbiter: exactly one caller can occupy each
+    // slot, and the first caller that finds no free slot is rejected.
+    for (let slot = 1; slot <= maxRequests; slot += 1) {
+      try {
+        await timed(sql`
+          INSERT INTO ${rateLimitsTable} (rate_key, request_count, expires_at)
+          VALUES (${`${key}:${slot}`}, ${ydbUint32(slot)}, ${ydbTimestamp(expiresAt)});
+        `);
 
-    return sql.begin(transactionOptions(), async tx => {
-      const updated = firstResultSet(
-        await tx`
-          UPDATE ${rateLimitsTable}
-          SET request_count = request_count + ${ydbUint32(1)}
-          WHERE
-            rate_key = ${key}
-            AND request_count < ${maxRequestsValue}
-          RETURNING request_count;
-        `,
-      );
-      if (updated.length > 0) {
         return true;
+      } catch (error) {
+        if (!isOccupiedSlotError(error)) {
+          throw error;
+        }
       }
+    }
 
-      const existing = firstResultSet(
-        await tx`
-          SELECT request_count
-          FROM ${rateLimitsTable}
-          WHERE rate_key = ${key};
-        `,
-      );
-      if (existing.length > 0) {
-        return false;
-      }
-
-      await tx`
-        INSERT INTO ${rateLimitsTable} (rate_key, request_count, expires_at)
-        VALUES (${key}, ${ydbUint32(1)}, ${ydbTimestamp(expiresAt)});
-      `;
-
-      return true;
-    });
+    return false;
   });
 }
 
-export const _private = { rateKey, settings, windowStart };
+export const _private = { isOccupiedSlotError, rateKey, settings, windowStart };


### PR DESCRIPTION
## Что исправлено
- rate limit теперь занимает уникальные YDB-слоты через INSERT вместо конкурентного обновления общего счётчика
- шестой и последующие параллельные запросы не могут пройти лимит 5
- integration-тест усилен до 5 раундов по 10 параллельных запросов

## Проверки
- npm test (functions/lead-intake)
- npm run lint:public
- npm run test:build

Исправляет повторно воспроизведённую гонку из production workflow #31632621643.