### PR TITLE
feat: cover production monitoring blind spots

### DIFF
--- a/docs/launch-checklist.md
+++ b/docs/launch-checklist.md
@@ -109,7 +109,9 @@ npm run import:leads -- \
       в отдельную админскую группу.
 - [ ] Создай резервный канал `ZvenFit Email alerts`.
 - [ ] Включи уведомления для `Alarm`, `Warning`, `OK` и повтор каждые 30 минут.
-- [ ] Создай девять алертов и подключи к каждому оба канала.
+- [ ] Создай тринадцать алертов и подключи к каждому оба канала.
+- [ ] Для `zvenfit_retry_worker_heartbeat` проверь политику `No data → Alarm`.
+- [ ] Для `zvenfit_telegram_delivery_backlog` проверь Warning 10 минут и Alarm 30 минут.
 - [ ] Для `zvenfit_ydb_storage_usage` проверь запросы `A/B/C`, пороги Warning 70%,
       Alarm 85% и политику `No data → Warning`.
 - [ ] Запусти синтетическую проверку:

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -165,27 +165,34 @@ Telegram username, UTM и тело ответа Fitbase в лог не попа�
 Отдельный бот Yandex Cloud важен: он сможет сообщить о проблеме, даже если бот
 заявок потерял токен, доступ к чату или был заблокирован.
 
-Создай девять обычных алертов. Шесть сигналов lead pipeline используют прямые
-OTLP-метрики приложения, два runtime-сигнала — автоматическую метрику Cloud
-Functions, storage alert — две автоматические метрики YDB:
+Создай тринадцать обычных алертов. Девять сигналов lead pipeline используют
+прямые OTLP-метрики приложения, Fitbase — агрегат его application logs, runtime
+и retry trigger — автоматические метрики Cloud Functions, storage alert — две
+автоматические метрики YDB:
 
 | Alert ID                              | Metric / signal                              | Function | Warning |   Alarm | Window | Delay | No data |
 | ------------------------------------- | -------------------------------------------- | -------- | ------: | ------: | -----: | ----: | ------- |
 | `zvenfit_lead_storage_errors`         | direct `zvenfit_lead_storage_errors`         | `max`    |   `> 0` | `> 0.5` |     5m |   30s | OK      |
 | `zvenfit_permanent_telegram_failures` | direct `zvenfit_telegram_delivery_failed_1m` | `max`    |   `> 0` | `> 0.5` |     5m |   30s | OK      |
-| `zvenfit_fitbase_errors`              | `functions_errors`, schedule only            | `max`    |   `> 0` | `> 0.5` |    10m |   30s | OK      |
+| `zvenfit_fitbase_errors`              | log aggregate `zvenfit_fitbase_errors_5m`    | `max`    |   `> 0` | `> 0.5` |    10m |    3m | OK      |
 | `zvenfit_function_runtime_errors`     | `functions_errors` for both function names   | `sum`    |   `> 0` | `> 0.5` |     5m |   30s | OK      |
 | `zvenfit_ydb_retries`                 | direct `zvenfit_ydb_retries_5m`              | `sum`    | `> 4.5` | `> 5.5` |    10m |   30s | OK      |
 | `zvenfit_slow_ydb_operations`         | direct `zvenfit_ydb_slow_operations_5m`      | `sum`    | `> 0.5` | `> 2.5` |    10m |   30s | OK      |
 | `zvenfit_rate-limited_leads`          | direct `zvenfit_lead_rate_limited_5m`        | `sum`    |   `> 0` |   `> 5` |    10m |   30s | OK      |
 | `zvenfit_persisted_leads_volume`      | direct `zvenfit_leads_persisted_5m`          | `sum`    |  `> 10` |  `> 20` |    10m |   30s | OK      |
+| `zvenfit_retry_worker_heartbeat`      | direct `zvenfit_retry_worker_heartbeat`      | `last`   |   `< 0` | `< 0.5` |     5m |   30s | Alarm   |
+| `zvenfit_telegram_delivery_backlog`   | direct oldest pending age, seconds           | `last`   | `> 600` | `> 1800` |    5m |   30s | OK      |
+| `zvenfit_rate_limit_health_errors`    | direct `zvenfit_rate_limit_errors_5m`        | `sum`    |   `> 0` |   `> 2` |    10m |   30s | OK      |
+| `zvenfit_retry_trigger_errors`        | trigger access and invocation errors         | `max`    |   `> 0` | `> 0.5` |     5m |   30s | OK      |
 | `zvenfit_ydb_storage_usage`           | query `C`, storage used percent              | `last`   | `>= 70` | `>= 85` |    15m |   30s | Warning |
 
 Monium требует `Alarm > Warning`. Для целочисленных счётчиков промежуточное
 значение `0.5` техническое. Для error counters первая точка со значением `1`
 сразу даёт `Alarm`; для slow YDB пороги намеренно разведены: единичное превышение
-даёт `Warning`, а `Alarm` требует минимум три превышения за 10 минут. Прямые и
-platform metrics используют задержку вычисления `30s`.
+даёт `Warning`, а `Alarm` требует минимум три превышения за 10 минут. Heartbeat
+в норме всегда равен `1`; его основная проверка — политика `No data = Alarm`.
+Прямые и platform metrics используют задержку вычисления `30s`, а log aggregate
+Fitbase — `3m`, чтобы дождаться поставки логов.
 
 Приложение экспортирует event counters с `DELTA` temporality. Каждая инвокация
 serverless-функции создаёт отдельный одноразовый MeterProvider, поэтому
@@ -200,11 +207,29 @@ serverless-функции создаёт отдельный одноразовы
 {project="folder__b1ge1e4iopttj79hfdfm", cluster="default", service="zvenfit-frontend", name="zvenfit_lead_storage_errors"}
 ```
 
-Lead-функция отправляет шесть метрик напрямую в Monium по OTLP с
+Lead-функция отправляет девять alert-метрик и одну dashboard-метрику напрямую в Monium по OTLP с
 `service="zvenfit-frontend"`, поэтому эти alerts не зависят от Preview-конвейера
-метрик по логам. Их имена перечислены в таблице выше. Для записи используется
+метрик по логам. Новые health-сигналы:
+
+- `zvenfit_retry_worker_heartbeat` — успешное завершение минутного retry pass;
+- `zvenfit_telegram_pending_leads` — текущий размер очереди для dashboard;
+- `zvenfit_telegram_oldest_pending_age_seconds` — возраст старейшей ожидающей заявки;
+- `zvenfit_rate_limit_errors_5m` — недоступность fail-open rate limiter.
+
+Heartbeat записывается только после retry pass и read-only проверки очереди.
+Если timer не вызвал функцию, YDB недоступна или OTLP export перестал работать,
+точки исчезнут и heartbeat alert перейдёт в `Alarm`. Для записи используется
 GitHub Secret `MONIUM_API_KEY`: API key runtime SA с ролью
-`monium.telemetry.writer` и scope `yc.monium.metrics.write`.
+`monium.metrics.writer` и scope `yc.monium.metrics.write`.
+
+Fitbase не использует `functions_errors` как основной application alert: handler
+перехватывает недоступность upstream и возвращает контролируемый HTTP `502`, то
+есть invocation может считаться успешно завершённым. Поэтому
+`zvenfit_fitbase_errors` проверяет созданный log aggregate:
+
+```text
+{project="folder__b1ge1e4iopttj79hfdfm", cluster="default", service="logging_aggregates", name="zvenfit_fitbase_errors_5m"}
+```
 
 Селектор автоматической метрики runtime errors:
 
@@ -215,6 +240,15 @@ GitHub Secret `MONIUM_API_KEY`: API key runtime SA с ролью
 Несмотря на название метки, live Monitoring API возвращает в `resource_id`
 имена функций, а не их облачные ID `d4e…`. Селектор проверен по фактическим
 сериям `functions_errors` обеих production-функций.
+
+Селектор ошибок минутного retry trigger:
+
+```text
+{project="folder__b1ge1e4iopttj79hfdfm", service="serverless-functions", name="serverless.triggers.access_error_per_second|serverless.triggers.error_per_second", trigger="a1smkp9ng1f4g9vqgm7u", type="request"}
+```
+
+Он отдельно ловит потерю `functionInvoker`, ошибки вызова функции и другие
+проблемы trigger до того, как истечёт пятиминутное окно heartbeat.
 
 Для `zvenfit_ydb_storage_usage` создай три запроса в текстовом режиме:
 
@@ -230,16 +264,18 @@ C: (A / B) * 100
 пользовательские данные, служебные данные и вторичные индексы, поэтому процент
 отражает реальный расход лимита.
 
-Для direct и runtime алертов отсутствие точек считается `OK`. Для storage
-отсутствие любой из двух platform metrics считается `Warning`: потеря данных о
-заполнении базы не должна выглядеть как исправное состояние. Во все девять
-алертов добавь оба канала: **ZvenFit Telegram alerts** и **ZvenFit Email alerts**.
+Для direct и runtime алертов отсутствие точек обычно считается `OK`. Исключение —
+heartbeat: отсутствие точек считается `Alarm`. Для storage отсутствие любой из
+двух platform metrics считается `Warning`: потеря данных о заполнении базы не
+должна выглядеть как исправное состояние. Во все тринадцать алертов добавь оба
+канала: **ZvenFit Telegram alerts** и **ZvenFit Email alerts**.
 
 ## Проверка доставки алертов
 
 Скрипт ниже пишет синтетические записи без персональных данных и проверяет raw
-logs и оставленные диагностические log metrics. Production alerts от них больше
-не зависят:
+logs и диагностические log metrics. Событие `fitbase_schedule_error` намеренно
+переведёт production Fitbase alert в `Alarm`, поэтому запускай скрипт только при
+явной проверке каналов доставки:
 
 ```bash
 bash scripts/test-monitoring-alerts.sh --confirm
@@ -252,8 +288,8 @@ bash scripts/test-monitoring-alerts.sh --confirm
 ## Dashboard
 
 Для вызовов, runtime errors и latency используй готовые service dashboards
-Cloud Functions. В отдельный компактный dashboard добавь семь итоговых метрик
-выше столбцами (`max`, без интерполяции пропусков) и виджеты статуса девяти
+Cloud Functions. В отдельный компактный dashboard добавь ключевые error counters,
+heartbeat, размер и возраст Telegram-очереди, а также виджеты статуса тринадцати
 алертов. Для YDB отдельно выведи количество `ydb_retry`, `ydb_slow_operation`
 и p95 поля `duration_ms` из `ydb_operation_completed`, а также `C` — процент
 использованного хранилища.
@@ -262,7 +298,7 @@ Cloud Functions. В отдельный компактный dashboard добав
 
 - Automatic Yandex Cloud metrics and service dashboards: free.
 - Seven log-derived metrics at one point per window: less than `0.15 RUB/month`.
-- Nine continuously evaluated alerts: about `9.72 RUB/month` at the current
+- Thirteen continuously evaluated alerts: about `14.04 RUB/month` at the current
   tariff of `1.5 RUB / 1000 alert-hours`.
 - Telegram and email notification channels: no separate charge; SMS and calls
   are not enabled.

--- a/functions/lead-intake/src/__tests__/handler-monitoring.test.ts
+++ b/functions/lead-intake/src/__tests__/handler-monitoring.test.ts
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { _private } from '../handler';
+
+import type { LeadStore } from '../types';
+
+test('timer exports queue health and heartbeat after a successful retry pass', async () => {
+  const gauges: Array<{ name: string; value: number }> = [];
+  const handler = _private.createHandler({
+    loggerFactory: () => ({ error() {} }),
+    metricsFactory: () => ({
+      addCounter() {},
+      recordGauge(name, value) {
+        gauges.push({ name, value });
+      },
+      async flush() {},
+    }),
+    now: () => new Date('2026-08-08T12:00:00.000Z'),
+    store: {
+      async saveLead() {
+        throw new Error('not_used');
+      },
+      async claimForTelegram() {
+        return null;
+      },
+      async markTelegramDelivered() {},
+      async markTelegramFailed() {},
+      async listTelegramCandidates() {
+        return [];
+      },
+      async getTelegramQueueHealth() {
+        return { pendingCount: 2, oldestPendingAgeSeconds: 901 };
+      },
+    } satisfies LeadStore,
+  });
+
+  const result = await handler({
+    messages: [{ event_metadata: { event_type: 'yandex.cloud.events.serverless.triggers.TimerMessage' } }],
+  });
+
+  assert.deepEqual(result, { processed: 0, sent: 0, pending: 0, failed: 0, skipped: 0 });
+  assert.deepEqual(gauges, [
+    { name: 'zvenfit_telegram_pending_leads', value: 2 },
+    { name: 'zvenfit_telegram_oldest_pending_age_seconds', value: 901 },
+    { name: 'zvenfit_retry_worker_heartbeat', value: 1 },
+  ]);
+});

--- a/functions/lead-intake/src/__tests__/handler.test.ts
+++ b/functions/lead-intake/src/__tests__/handler.test.ts
@@ -61,7 +61,12 @@ function dependencies(store: StoreMock, overrides: Partial<HandlerDependencies> 
     maxAttempts: () => 12,
     now: () => NOW,
     rateLimiter: async () => true,
-    store: store as LeadStore,
+    store: {
+      async getTelegramQueueHealth() {
+        return { pendingCount: 0, oldestPendingAgeSeconds: 0 };
+      },
+      ...store,
+    } as LeadStore,
     telegramSender: async () => {},
     uuid: () => DELIVERY_ID,
     ...overrides,
@@ -132,6 +137,9 @@ test('flushes metrics after asynchronous POST events have been recorded', async 
       metricsFactory: () => ({
         addCounter(name) {
           order.push(`metric:${name}`);
+        },
+        recordGauge(name, value) {
+          order.push(`gauge:${name}:${value}`);
         },
         async flush() {
           order.push('metrics_flushed');
@@ -262,6 +270,7 @@ test('POST returns 503 and does not call Telegram when durable storage fails', a
           addCounter(name, value = 1) {
             metricCounters.push({ name, value });
           },
+          recordGauge() {},
           async flush() {
             metricFlushes += 1;
           },

--- a/functions/lead-intake/src/handler.ts
+++ b/functions/lead-intake/src/handler.ts
@@ -124,6 +124,10 @@ function createHandler(overrides: Partial<HandlerDependencies> = {}): CloudHandl
     try {
       if (isTimerEvent(event)) {
         const retrySummary = await retryPendingLeads(dependencies, logger);
+        const queueHealth = await dependencies.store.getTelegramQueueHealth({ now: dependencies.now(), logger });
+        metrics.recordGauge('zvenfit_telegram_pending_leads', queueHealth.pendingCount);
+        metrics.recordGauge('zvenfit_telegram_oldest_pending_age_seconds', queueHealth.oldestPendingAgeSeconds);
+        metrics.recordGauge('zvenfit_retry_worker_heartbeat', 1);
 
         return retrySummary;
       }

--- a/functions/lead-intake/src/observability/__tests__/event-metrics.test.ts
+++ b/functions/lead-intake/src/observability/__tests__/event-metrics.test.ts
@@ -12,6 +12,7 @@ function capture() {
     addCounter(name, value = 1) {
       counters.push({ name, value });
     },
+    recordGauge() {},
     async flush() {},
   };
   const logger: LoggerLike = {
@@ -36,6 +37,7 @@ test('records direct counters for lead pipeline events without changing logs', (
   captured.logger.warn?.({ event: 'lead_submission_blocked', reason: 'rate_limit' });
   captured.logger.warn?.({ event: 'ydb_retry', retry_attempts: 3 });
   captured.logger.warn?.({ event: 'ydb_slow_operation' });
+  captured.logger.error({ event: 'lead_rate_limit_error' });
   captured.logger.error({ event: 'telegram_delivery_failed_permanently' });
   captured.logger.error({ event: 'telegram_delivery_retry_error' });
 
@@ -44,10 +46,11 @@ test('records direct counters for lead pipeline events without changing logs', (
     { name: 'zvenfit_lead_rate_limited_5m', value: 1 },
     { name: 'zvenfit_ydb_retries_5m', value: 3 },
     { name: 'zvenfit_ydb_slow_operations_5m', value: 1 },
+    { name: 'zvenfit_rate_limit_errors_5m', value: 1 },
     { name: 'zvenfit_telegram_delivery_failed_1m', value: 1 },
     { name: 'zvenfit_lead_storage_errors', value: 1 },
   ]);
-  assert.equal(captured.logs.length, 6);
+  assert.equal(captured.logs.length, 7);
 });
 
 test('ignores non-rate-limit blocks and unrelated events', () => {

--- a/functions/lead-intake/src/observability/event-metrics.ts
+++ b/functions/lead-intake/src/observability/event-metrics.ts
@@ -2,6 +2,7 @@ import type { ApplicationMetrics, JsonObject, LoggerLike } from '../types';
 
 const EVENT_COUNTERS: Record<string, string> = {
   lead_persisted: 'zvenfit_leads_persisted_5m',
+  lead_rate_limit_error: 'zvenfit_rate_limit_errors_5m',
   telegram_delivery_failed_permanently: 'zvenfit_telegram_delivery_failed_1m',
   telegram_delivery_retry_error: 'zvenfit_lead_storage_errors',
   ydb_retry: 'zvenfit_ydb_retries_5m',

--- a/functions/lead-intake/src/types.ts
+++ b/functions/lead-intake/src/types.ts
@@ -33,6 +33,7 @@ export interface LoggerLike {
 
 export interface ApplicationMetrics {
   addCounter(name: string, value?: number): void;
+  recordGauge(name: string, value: number): void;
   flush(): Promise<void>;
 }
 
@@ -67,6 +68,11 @@ export interface StoreOptions {
   logger?: LoggerLike;
 }
 
+export interface TelegramQueueHealth {
+  pendingCount: number;
+  oldestPendingAgeSeconds: number;
+}
+
 export interface LeadStore {
   saveLead(lead: Lead, options?: StoreOptions): Promise<{ created: boolean; telegramStatus: TelegramStatus }>;
   claimForTelegram(args: {
@@ -91,6 +97,7 @@ export interface LeadStore {
     logger?: LoggerLike;
   }): Promise<void>;
   listTelegramCandidates(args: { now: Date; limit: number; logger?: LoggerLike }): Promise<string[]>;
+  getTelegramQueueHealth(args: { now: Date; logger?: LoggerLike }): Promise<TelegramQueueHealth>;
 }
 
 export interface HandlerDependencies {

--- a/functions/lead-intake/src/ydb/__tests__/config.test.ts
+++ b/functions/lead-intake/src/ydb/__tests__/config.test.ts
@@ -22,6 +22,7 @@ test('validates data, migration, and rate-limit table identifiers', () => {
   withEnv('YDB_LEADS_TABLE', 'leads_test', () => {
     assert.equal(config.tableName(), 'leads_test');
     assert.equal(config.migrationTableName(), 'leads_test_migrations');
+    assert.equal(config.queueHealthIndexName(), 'idx_telegram_status_created');
   });
 
   withEnv('YDB_LEADS_TABLE', 'leads; DROP TABLE leads', () => {

--- a/functions/lead-intake/src/ydb/__tests__/integration/lead-store.test.ts
+++ b/functions/lead-intake/src/ydb/__tests__/integration/lead-store.test.ts
@@ -56,7 +56,7 @@ test(
     process.env.LEAD_RATE_LIMIT_SECRET = 'integration-test-secret-not-production-32';
 
     try {
-      assert.deepEqual(await runMigrations({ log: { info() {} } }), [1]);
+      assert.deepEqual(await runMigrations({ log: { info() {} } }), [1, 2]);
       assert.deepEqual(await runMigrations({ log: { info() {} } }), []);
 
       const migrationClient = await createYdbClient();
@@ -92,6 +92,10 @@ test(
 
       assert.deepEqual(saved.map(result => result.created).sort(), [false, true]);
       assert.deepEqual(await leadStore.listTelegramCandidates({ now, limit: 10 }), [leadId]);
+      assert.deepEqual(await leadStore.getTelegramQueueHealth({ now }), {
+        pendingCount: 1,
+        oldestPendingAgeSeconds: 0,
+      });
 
       const leaseUntil = new Date(now.getTime() + 60_000);
       const claims = await Promise.all([
@@ -130,6 +134,10 @@ test(
         await leadStore.listTelegramCandidates({ now: new Date(afterLease.getTime() + 120_000), limit: 10 }),
         [],
       );
+      assert.deepEqual(await leadStore.getTelegramQueueHealth({ now: afterLease }), {
+        pendingCount: 0,
+        oldestPendingAgeSeconds: 0,
+      });
     } finally {
       await leadStore.close();
 

--- a/functions/lead-intake/src/ydb/__tests__/migrations.test.ts
+++ b/functions/lead-intake/src/ydb/__tests__/migrations.test.ts
@@ -6,7 +6,10 @@ import { MIGRATIONS, _private } from '../migrations';
 test('lead schema migrations are ordered, unique, and append-only', () => {
   assert.deepEqual(
     MIGRATIONS.map(migration => [migration.version, migration.name]),
-    [[1, 'create_lead_storage']],
+    [
+      [1, 'create_lead_storage'],
+      [2, 'add_telegram_queue_health_index'],
+    ],
   );
   assert.equal(new Set(MIGRATIONS.map(migration => migration.version)).size, MIGRATIONS.length);
   assert.equal(
@@ -17,10 +20,13 @@ test('lead schema migrations are ordered, unique, and append-only', () => {
 
 test('lead rows do not expire, while technical rate-limit counters do', () => {
   const leadsSchema = _private.createLeadsTable.toString();
+  const queueHealthIndexMigration = _private.createQueueHealthIndex.toString();
   const rateLimitsSchema = _private.createRateLimitsTable.toString();
 
   assert.doesNotMatch(leadsSchema, /\bexpires_at\b/);
   assert.doesNotMatch(leadsSchema, /\bTTL\b/);
   assert.match(rateLimitsSchema, /\bexpires_at\b/);
   assert.match(rateLimitsSchema, /\bTTL\b/);
+  assert.match(leadsSchema, /idx_telegram_status_created/);
+  assert.match(queueHealthIndexMigration, /queueHealthIndex/);
 });

--- a/functions/lead-intake/src/ydb/config.ts
+++ b/functions/lead-intake/src/ydb/config.ts
@@ -38,6 +38,10 @@ export function dueIndexName(): string {
   return 'idx_telegram_due';
 }
 
+export function queueHealthIndexName(): string {
+  return 'idx_telegram_status_created';
+}
+
 export function normalizeConnectionString(value: string | undefined): string {
   const connectionString = (value || '').trim();
 

--- a/functions/lead-intake/src/ydb/lead-store.ts
+++ b/functions/lead-intake/src/ydb/lead-store.ts
@@ -1,3 +1,9 @@
 export { close } from './context';
 export { importDeliveredLead, saveLead } from './lead-persistence';
-export { claimForTelegram, listTelegramCandidates, markTelegramDelivered, markTelegramFailed } from './telegram-queue';
+export {
+  claimForTelegram,
+  getTelegramQueueHealth,
+  listTelegramCandidates,
+  markTelegramDelivered,
+  markTelegramFailed,
+} from './telegram-queue';

--- a/functions/lead-intake/src/ydb/migrations.ts
+++ b/functions/lead-intake/src/ydb/migrations.ts
@@ -1,5 +1,12 @@
 import { createYdbClient } from './client';
-import { dueIndexName, migrationTableName, queryTimeoutMs, rateLimitsTableName, tableName } from './config';
+import {
+  dueIndexName,
+  migrationTableName,
+  queryTimeoutMs,
+  queueHealthIndexName,
+  rateLimitsTableName,
+  tableName,
+} from './config';
 
 import type { YdbClient, YdbQuery } from '../types';
 
@@ -8,6 +15,7 @@ interface MigrationContext extends YdbClient {
   migrationsTable: unknown;
   rateLimitsTable: unknown;
   dueIndex: unknown;
+  queueHealthIndex: unknown;
 }
 
 interface Migration {
@@ -45,6 +53,8 @@ async function createLeadsTable({ sql, leadsTable }: MigrationContext): Promise<
         INDEX idx_telegram_due GLOBAL SYNC
           ON (telegram_due_at, created_at)
           COVER (telegram_status),
+        INDEX idx_telegram_status_created GLOBAL SYNC
+          ON (telegram_status, created_at),
         PRIMARY KEY (lead_id)
       );
     `.idempotent(true),
@@ -69,6 +79,16 @@ async function createRateLimitsTable({ sql, rateLimitsTable }: MigrationContext)
 async function createLeadStorage(context: MigrationContext): Promise<void> {
   await createLeadsTable(context);
   await createRateLimitsTable(context);
+}
+
+async function createQueueHealthIndex({ sql, leadsTable, queueHealthIndex }: MigrationContext): Promise<void> {
+  await timed(
+    sql`
+      ALTER TABLE ${leadsTable}
+      ADD INDEX ${queueHealthIndex} GLOBAL SYNC
+      ON (telegram_status, created_at);
+    `.idempotent(true),
+  );
 }
 
 async function verifyLeadColumns({ sql, leadsTable }: MigrationContext): Promise<void> {
@@ -114,8 +134,28 @@ async function verifyLeadStorage(context: MigrationContext): Promise<void> {
   await verifyRateLimitsSchema(context);
 }
 
+async function verifyQueueHealthIndex({ sql, leadsTable, queueHealthIndex }: MigrationContext): Promise<void> {
+  await timed(
+    sql`
+      SELECT created_at
+      FROM ${leadsTable} VIEW ${queueHealthIndex}
+      WHERE telegram_status = ${'pending'} OR telegram_status = ${'sending'}
+      ORDER BY telegram_status, created_at
+      LIMIT ${1};
+    `
+      .idempotent(true)
+      .isolation('snapshotReadOnly'),
+  );
+}
+
 export const MIGRATIONS: readonly Migration[] = [
   { version: 1, name: 'create_lead_storage', apply: createLeadStorage, verify: verifyLeadStorage },
+  {
+    version: 2,
+    name: 'add_telegram_queue_health_index',
+    apply: createQueueHealthIndex,
+    verify: verifyQueueHealthIndex,
+  },
 ];
 
 async function ensureMigrationTable(sql: YdbClient['sql'], migrationsTable: unknown): Promise<void> {
@@ -208,6 +248,7 @@ function migrationContext(client: YdbClient): MigrationContext {
     migrationsTable: client.sql.identifier(migrationTableName()),
     rateLimitsTable: client.sql.identifier(rateLimitsTableName()),
     dueIndex: client.sql.identifier(dueIndexName()),
+    queueHealthIndex: client.sql.identifier(queueHealthIndexName()),
   };
 }
 
@@ -232,6 +273,7 @@ export async function runMigrations({ log = console }: { log?: MigrationLogger }
     }
 
     await verifyLeadStorage(context);
+    await verifyQueueHealthIndex(context);
 
     return completed;
   } finally {
@@ -244,6 +286,7 @@ export const _private = {
   appliedVersions,
   createLeadStorage,
   createLeadsTable,
+  createQueueHealthIndex,
   createRateLimitsTable,
   ensureMigrationTable,
   migrationContext,
@@ -252,5 +295,6 @@ export const _private = {
   validateLeadSchema,
   verifyLeadColumns,
   verifyLeadStorage,
+  verifyQueueHealthIndex,
   verifyRateLimitsSchema,
 };

--- a/functions/lead-intake/src/ydb/telegram-queue.ts
+++ b/functions/lead-intake/src/ydb/telegram-queue.ts
@@ -1,4 +1,4 @@
-import { dueIndexName, tableName } from './config';
+import { dueIndexName, queueHealthIndexName, tableName } from './config';
 import {
   firstResultSet,
   observed,
@@ -11,7 +11,7 @@ import {
   ydbUint32,
 } from './context';
 
-import type { ClaimedLead, LoggerLike } from '../types';
+import type { ClaimedLead, LoggerLike, TelegramQueueHealth } from '../types';
 
 export async function claimForTelegram({
   leadId,
@@ -177,5 +177,39 @@ export async function listTelegramCandidates({
     );
 
     return rows.map(row => stringValue(row.lead_id));
+  });
+}
+
+export async function getTelegramQueueHealth({
+  now,
+  logger,
+}: {
+  now: Date;
+  logger?: LoggerLike;
+}): Promise<TelegramQueueHealth> {
+  return observed('get_telegram_queue_health', logger, async sql => {
+    const leadsTable = sql.identifier(tableName());
+    const queueHealthIndex = sql.identifier(queueHealthIndexName());
+    const rows = firstResultSet(
+      await timed(
+        sql`
+          SELECT
+            COUNT(*) AS pending_count,
+            MIN(created_at) AS oldest_created_at
+          FROM ${leadsTable} VIEW ${queueHealthIndex}
+          WHERE telegram_status = ${'pending'} OR telegram_status = ${'sending'};
+        `
+          .idempotent(true)
+          .isolation('snapshotReadOnly'),
+      ),
+    );
+    const row = rows[0];
+    const pendingCount = Math.max(0, Number(row?.pending_count || 0));
+    const oldestCreatedAt = row?.oldest_created_at;
+    const oldestPendingAgeSeconds = oldestCreatedAt
+      ? Math.max(0, Math.floor((now.getTime() - toEpoch(oldestCreatedAt)) / 1000))
+      : 0;
+
+    return { pendingCount, oldestPendingAgeSeconds };
   });
 }

--- a/scripts/__tests__/monitoring-config.test.cjs
+++ b/scripts/__tests__/monitoring-config.test.cjs
@@ -44,7 +44,13 @@ test('every alert references a metric and is documented', () => {
     );
     assert.equal(alertIds.has(alert.id), false, `${alert.id} is duplicated`);
     assert.match(monitoringDocs, new RegExp(`\\b${alert.id}\\b`), `${alert.id} is missing from docs`);
-    assert.equal(alert.noData, alert.id === 'zvenfit_ydb_storage_usage' ? 'WARNING' : 'OK');
+    const expectedNoData =
+      alert.id === 'zvenfit_ydb_storage_usage'
+        ? 'WARNING'
+        : alert.id === 'zvenfit_retry_worker_heartbeat'
+          ? 'ALARM'
+          : 'OK';
+    assert.equal(alert.noData, expectedNoData);
     assert.equal(typeof alert.warning, 'number', `${alert.id} has no Warning threshold`);
     assert.equal(typeof alert.alarm, 'number', `${alert.id} has no Alarm threshold`);
     assert.equal(alert.alarm > alert.warning, true, `${alert.id} requires Alarm > Warning`);
@@ -52,7 +58,7 @@ test('every alert references a metric and is documented', () => {
     alertIds.add(alert.id);
   }
 
-  assert.equal(alertIds.size, 9);
+  assert.equal(alertIds.size, 13);
 });
 
 test('anti-spam and accepted lead volume thresholds are explicit', () => {
@@ -71,11 +77,11 @@ test('anti-spam and accepted lead volume thresholds are explicit', () => {
   );
 });
 
-test('alerts no longer depend on the Preview log aggregate pipeline', () => {
+test('only the caught Fitbase application error depends on the log aggregate pipeline', () => {
   const metricIds = new Set(config.logMetrics.map(metric => metric.id));
   const logAlerts = config.alerts.filter(alert => metricIds.has(alert.metricId));
 
-  assert.equal(logAlerts.length, 0);
+  assert.deepEqual(logAlerts.map(alert => alert.id), ['zvenfit_fitbase_errors']);
 });
 
 test('YDB retry thresholds expose reachable Warning and Alarm states', () => {
@@ -143,6 +149,9 @@ test('lead pipeline alerts use direct OTLP application metrics', () => {
     'zvenfit_slow_ydb_operations',
     'zvenfit_rate-limited_leads',
     'zvenfit_persisted_leads_volume',
+    'zvenfit_retry_worker_heartbeat',
+    'zvenfit_telegram_delivery_backlog',
+    'zvenfit_rate_limit_health_errors',
   ];
 
   for (const id of directIds) {
@@ -152,13 +161,42 @@ test('lead pipeline alerts use direct OTLP application metrics', () => {
   }
 });
 
-test('Fitbase alert uses the schedule runtime error metric', () => {
+test('Fitbase alert uses the application error aggregate because the handler catches upstream failures', () => {
   const alert = config.alerts.find(item => item.id === 'zvenfit_fitbase_errors');
 
-  assert.match(alert.metricSelector, /service="serverless-functions"/);
-  assert.match(alert.metricSelector, /name="functions_errors"/);
-  assert.match(alert.metricSelector, /resource_id="zvenfit-fitbase-schedule"/);
-  assert.equal(alert.delay, '30s');
+  assert.equal(alert.metricId, 'zvenfit_fitbase_errors_5m');
+  assert.match(alert.metricSelector, /service="logging_aggregates"/);
+  assert.match(alert.metricSelector, /name="zvenfit_fitbase_errors_5m"/);
+  assert.equal(alert.delay, '3m');
+  assert.match(source, /catch \(error\)[\s\S]*fitbase_schedule_error[\s\S]*jsonResponse\(502/);
+});
+
+test('retry worker health covers missing heartbeats, delivery backlog, and trigger failures', () => {
+  const heartbeat = config.alerts.find(item => item.id === 'zvenfit_retry_worker_heartbeat');
+  const backlog = config.alerts.find(item => item.id === 'zvenfit_telegram_delivery_backlog');
+  const trigger = config.alerts.find(item => item.id === 'zvenfit_retry_trigger_errors');
+
+  assert.equal(heartbeat.noData, 'ALARM');
+  assert.equal(heartbeat.aggregation, 'last');
+  assert.match(heartbeat.metricSelector, /name="zvenfit_retry_worker_heartbeat"/);
+  assert.deepEqual(
+    { warning: backlog.warning, alarm: backlog.alarm, aggregation: backlog.aggregation },
+    { warning: 600, alarm: 1800, aggregation: 'last' },
+  );
+  assert.match(backlog.metricSelector, /name="zvenfit_telegram_oldest_pending_age_seconds"/);
+  assert.match(trigger.metricSelector, /serverless\.triggers\.access_error_per_second/);
+  assert.match(trigger.metricSelector, /serverless\.triggers\.error_per_second/);
+  assert.match(trigger.metricSelector, /trigger="a1smkp9ng1f4g9vqgm7u"/);
+});
+
+test('rate limiter fail-open path has a direct health alert', () => {
+  const alert = config.alerts.find(item => item.id === 'zvenfit_rate_limit_health_errors');
+
+  assert.match(alert.metricSelector, /name="zvenfit_rate_limit_errors_5m"/);
+  assert.deepEqual(
+    { warning: alert.warning, alarm: alert.alarm, window: alert.window },
+    { warning: 0, alarm: 2, window: '10m' },
+  );
 });
 
 test('transient Telegram retries remain log-only', () => {
@@ -236,5 +274,5 @@ test('monitoring smoke script requires confirmation and covers every log metric'
   }
 
   assert.match(smokeScript, /reason\\?":\\?"rate_limit/);
-  assert.match(smokeScript, /No production alert depends on these Preview log aggregates/);
+  assert.match(smokeScript, /synthetic Fitbase event intentionally exercises the production Fitbase alert/);
 });

--- a/scripts/monitoring.config.json
+++ b/scripts/monitoring.config.json
@@ -109,13 +109,14 @@
     },
     {
       "id": "zvenfit_fitbase_errors",
-      "metricSelector": "{project=\"folder__b1ge1e4iopttj79hfdfm\", cluster=\"default\", service=\"serverless-functions\", name=\"functions_errors\", resource_id=\"zvenfit-fitbase-schedule\"}",
+      "metricId": "zvenfit_fitbase_errors_5m",
+      "metricSelector": "{project=\"folder__b1ge1e4iopttj79hfdfm\", cluster=\"default\", service=\"logging_aggregates\", name=\"zvenfit_fitbase_errors_5m\"}",
       "aggregation": "max",
       "operator": ">",
       "warning": 0,
       "alarm": 0.5,
       "window": "10m",
-      "delay": "30s",
+      "delay": "3m",
       "noData": "OK"
     },
     {
@@ -170,6 +171,50 @@
       "warning": 10,
       "alarm": 20,
       "window": "10m",
+      "delay": "30s",
+      "noData": "OK"
+    },
+    {
+      "id": "zvenfit_retry_worker_heartbeat",
+      "metricSelector": "{project=\"folder__b1ge1e4iopttj79hfdfm\", cluster=\"default\", service=\"zvenfit-frontend\", name=\"zvenfit_retry_worker_heartbeat\"}",
+      "aggregation": "last",
+      "operator": "<",
+      "warning": 0,
+      "alarm": 0.5,
+      "window": "5m",
+      "delay": "30s",
+      "noData": "ALARM"
+    },
+    {
+      "id": "zvenfit_telegram_delivery_backlog",
+      "metricSelector": "{project=\"folder__b1ge1e4iopttj79hfdfm\", cluster=\"default\", service=\"zvenfit-frontend\", name=\"zvenfit_telegram_oldest_pending_age_seconds\"}",
+      "aggregation": "last",
+      "operator": ">",
+      "warning": 600,
+      "alarm": 1800,
+      "window": "5m",
+      "delay": "30s",
+      "noData": "OK"
+    },
+    {
+      "id": "zvenfit_rate_limit_health_errors",
+      "metricSelector": "{project=\"folder__b1ge1e4iopttj79hfdfm\", cluster=\"default\", service=\"zvenfit-frontend\", name=\"zvenfit_rate_limit_errors_5m\"}",
+      "aggregation": "sum",
+      "operator": ">",
+      "warning": 0,
+      "alarm": 2,
+      "window": "10m",
+      "delay": "30s",
+      "noData": "OK"
+    },
+    {
+      "id": "zvenfit_retry_trigger_errors",
+      "metricSelector": "{project=\"folder__b1ge1e4iopttj79hfdfm\", service=\"serverless-functions\", name=\"serverless.triggers.access_error_per_second|serverless.triggers.error_per_second\", trigger=\"a1smkp9ng1f4g9vqgm7u\", type=\"request\"}",
+      "aggregation": "max",
+      "operator": ">",
+      "warning": 0,
+      "alarm": 0.5,
+      "window": "5m",
       "delay": "30s",
       "noData": "OK"
     },

--- a/scripts/test-monitoring-alerts.sh
+++ b/scripts/test-monitoring-alerts.sh
@@ -55,6 +55,6 @@ for _ in {1..21}; do
 done
 
 echo "test-monitoring-alerts: synthetic events written to ${LOG_GROUP_NAME}"
-echo "No production alert depends on these Preview log aggregates; use this output for diagnostics only."
+echo "The synthetic Fitbase event intentionally exercises the production Fitbase alert."
 echo "The YDB storage alert must be checked against live platform metrics, not synthetic logs."
 echo "Verify Telegram and email delivery, then acknowledge the test alerts in Monitoring."


### PR DESCRIPTION
## Что сделано
- heartbeat минутного Telegram retry worker с No data → Alarm
- метрики размера и возраста pending Telegram-очереди
- отдельный alert для fail-open rate limiter
- platform alert ошибок retry trigger
- Fitbase alert переведён с runtime errors на application log metric
- индекс YDB для дешёвой проверки очереди
- monitoring contract, unit/integration tests и документация обновлены

## Проверки
- npm run test:lead-fn
- npm run test:schedule-fn
- npm run test:monitoring
- npm run lint:public
- npm run test:build