### PR TITLE
fix: make heartbeat and queue gauges reliable

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -180,7 +180,7 @@ Telegram username, UTM и тело ответа Fitbase в лог не попа�
 | `zvenfit_slow_ydb_operations`         | direct `zvenfit_ydb_slow_operations_5m`      | `sum`    | `> 0.5` | `> 2.5` |    10m |   30s | OK      |
 | `zvenfit_rate-limited_leads`          | direct `zvenfit_lead_rate_limited_5m`        | `sum`    |   `> 0` |   `> 5` |    10m |   30s | OK      |
 | `zvenfit_persisted_leads_volume`      | direct `zvenfit_leads_persisted_5m`          | `sum`    |  `> 10` |  `> 20` |    10m |   30s | OK      |
-| `zvenfit_retry_worker_heartbeat`      | direct `zvenfit_retry_worker_heartbeat`      | `last`   |   `< 0` | `< 0.5` |     5m |   30s | Alarm   |
+| `zvenfit_retry_worker_heartbeat`      | direct `zvenfit_retry_worker_heartbeat`      | `last`   | `< 0.9` | `< 0.5` |     5m |   30s | Alarm   |
 | `zvenfit_telegram_delivery_backlog`   | direct oldest pending age, seconds           | `last`   | `> 600` | `> 1800` |    5m |   30s | OK      |
 | `zvenfit_rate_limit_health_errors`    | direct `zvenfit_rate_limit_errors_5m`        | `sum`    |   `> 0` |   `> 2` |    10m |   30s | OK      |
 | `zvenfit_retry_trigger_errors`        | trigger access and invocation errors         | `max`    |   `> 0` | `> 0.5` |     5m |   30s | OK      |

--- a/functions/lead-intake/src/observability/__tests__/metrics.test.ts
+++ b/functions/lead-intake/src/observability/__tests__/metrics.test.ts
@@ -212,6 +212,41 @@ test('collects once and waits for the exporter callback before shutdown', async 
   assert.deepEqual(metric.dataPoints[0]?.attributes, { outcome: 'stored' });
 });
 
+test('exports zero-valued gauges as cumulative instant values', async () => {
+  let exportedMetrics: ResourceMetrics | undefined;
+  const exporter: PushMetricExporter = {
+    export(metrics, resultCallback) {
+      exportedMetrics = metrics;
+      resultCallback({ code: ExportResultCode.SUCCESS });
+    },
+    async forceFlush() {},
+    async shutdown() {},
+  };
+  const transport = _private.createOtelTransport(
+    { endpoint: 'https://example.test', headers: {}, timeoutMs: 100 },
+    () => exporter,
+  );
+
+  transport.recordGauge('zvenfit_telegram_pending_leads', 0);
+  transport.recordGauge('zvenfit_telegram_oldest_pending_age_seconds', 0);
+  transport.recordGauge('zvenfit_retry_worker_heartbeat', 1);
+  await transport.flush();
+
+  const metrics = exportedMetrics?.scopeMetrics.flatMap(scope => scope.metrics) ?? [];
+  const gauges = new Map(metrics.map(metric => [metric.descriptor.name, metric]));
+
+  for (const [name, expectedValue] of [
+    ['zvenfit_telegram_pending_leads', 0],
+    ['zvenfit_telegram_oldest_pending_age_seconds', 0],
+    ['zvenfit_retry_worker_heartbeat', 1],
+  ] as const) {
+    const gauge = gauges.get(name);
+    assert.ok(gauge, `${name} was not exported`);
+    assert.equal(gauge.aggregationTemporality, AggregationTemporality.CUMULATIVE);
+    assert.equal(gauge.dataPoints[0]?.value, expectedValue);
+  }
+});
+
 test('rejects when the exporter callback reports a failure', async () => {
   const exporter: PushMetricExporter = {
     export(_metrics, resultCallback) {

--- a/functions/lead-intake/src/observability/otel-transport.ts
+++ b/functions/lead-intake/src/observability/otel-transport.ts
@@ -2,6 +2,7 @@ import { ExportResultCode } from '@opentelemetry/core';
 import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-proto';
 import {
   AggregationTemporality,
+  InstrumentType,
   MeterProvider,
   MetricReader,
   type PushMetricExporter,
@@ -174,13 +175,27 @@ function createOtelExporter(options: MetricsTransportOptions): PushMetricExporte
   });
 }
 
+function selectAggregationTemporality(instrumentType: InstrumentType): AggregationTemporality {
+  switch (instrumentType) {
+    case InstrumentType.COUNTER:
+    case InstrumentType.OBSERVABLE_COUNTER:
+    case InstrumentType.HISTOGRAM:
+      return AggregationTemporality.DELTA;
+    default:
+      return AggregationTemporality.CUMULATIVE;
+  }
+}
+
 export function createOtelTransport(
   options: MetricsTransportOptions,
   exporterFactory: MetricsExporterFactory = createOtelExporter,
 ): MetricsTransport {
   const exporter = exporterFactory(options);
   const reader = new OneShotMetricReader({
-    aggregationTemporalitySelector: () => AggregationTemporality.DELTA,
+    // Event counters are deltas for each short-lived function invocation.
+    // Gauges are cumulative instant values so an explicit zero remains a
+    // real sample instead of looking like missing telemetry in Monium.
+    aggregationTemporalitySelector: selectAggregationTemporality,
   });
   const provider = new MeterProvider({ readers: [reader] });
 

--- a/scripts/__tests__/monitoring-config.test.cjs
+++ b/scripts/__tests__/monitoring-config.test.cjs
@@ -53,7 +53,9 @@ test('every alert references a metric and is documented', () => {
     assert.equal(alert.noData, expectedNoData);
     assert.equal(typeof alert.warning, 'number', `${alert.id} has no Warning threshold`);
     assert.equal(typeof alert.alarm, 'number', `${alert.id} has no Alarm threshold`);
-    assert.equal(alert.alarm > alert.warning, true, `${alert.id} requires Alarm > Warning`);
+    const alarmIsMoreSevere =
+      alert.operator === '<' ? alert.alarm < alert.warning : alert.alarm > alert.warning;
+    assert.equal(alarmIsMoreSevere, true, `${alert.id} has inverted Warning and Alarm thresholds`);
     assert.equal(typeof alert.delay, 'string', `${alert.id} has no evaluation delay`);
     alertIds.add(alert.id);
   }
@@ -178,6 +180,12 @@ test('retry worker health covers missing heartbeats, delivery backlog, and trigg
 
   assert.equal(heartbeat.noData, 'ALARM');
   assert.equal(heartbeat.aggregation, 'last');
+  assert.equal(heartbeat.operator, '<');
+  assert.deepEqual(
+    { warning: heartbeat.warning, alarm: heartbeat.alarm },
+    { warning: 0.9, alarm: 0.5 },
+  );
+  assert.ok(heartbeat.alarm < heartbeat.warning);
   assert.match(heartbeat.metricSelector, /name="zvenfit_retry_worker_heartbeat"/);
   assert.deepEqual(
     { warning: backlog.warning, alarm: backlog.alarm, aggregation: backlog.aggregation },

--- a/scripts/monitoring.config.json
+++ b/scripts/monitoring.config.json
@@ -179,7 +179,7 @@
       "metricSelector": "{project=\"folder__b1ge1e4iopttj79hfdfm\", cluster=\"default\", service=\"zvenfit-frontend\", name=\"zvenfit_retry_worker_heartbeat\"}",
       "aggregation": "last",
       "operator": "<",
-      "warning": 0,
+      "warning": 0.9,
       "alarm": 0.5,
       "window": "5m",
       "delay": "30s",


### PR DESCRIPTION
## Что исправлено
- валидные пороги heartbeat-алерта для оператора less-than
- counters остаются DELTA, gauges экспортируются как CUMULATIVE instant values
- нулевые pending/oldest-age значения теперь являются реальными точками, а не no-data
- добавлен regression-тест на экспорт нулевых gauge-метрик

## Проверка
- npm test в functions/lead-intake: 41 unit + typecheck + deployment artifact
- npm run test:monitoring: 18/18
- git diff --check