### PR TITLE
fix: keep YDB rate-limit test inside TTL window

### DIFF
--- a/functions/lead-intake/src/ydb/__tests__/integration/lead-store.test.ts
+++ b/functions/lead-intake/src/ydb/__tests__/integration/lead-store.test.ts
@@ -73,12 +73,16 @@ test(
       assert.deepEqual(await runMigrations({ log: { info() {} } }), [1]);
       assert.deepEqual(await runMigrations({ log: { info() {} } }), []);
 
+      // Keep the fixture inside the active TTL window. A historical timestamp
+      // makes YDB immediately eligible to delete occupied rate-limit slots and
+      // can let a sixth concurrent request through while the test is running.
+      const rateLimitNow = new Date();
       for (let round = 0; round < 5; round += 1) {
         const rateLimitResults = await Promise.all(
           Array.from({ length: 10 }, () =>
             consumeLeadRateLimit({
               sourceIp: `203.0.113.${10 + round}`,
-              now: new Date('2026-08-10T10:01:00.000Z'),
+              now: rateLimitNow,
             }),
           ),
         );


### PR DESCRIPTION
## Что исправлено

- интеграционный тест rate limiter использует текущее окно вместо просроченной даты
- YDB TTL больше не удаляет тестовые слоты во время конкурентной проверки
- production rate-limit логика не меняется

## Проверка

- npm --prefix functions/lead-intake test
- npm run lint:public
- npm run test:schedule-fn
- npm run test:lead-import
- npm run test:monitoring

Причина падения deploy run 31640541957: тестовая дата 2026-08-10 уже была старше 24-часового TTL на момент запуска 2026-08-12.