### PR TITLE
chore: keep project knowledge base local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ sa-key.json
 
 # Local agent tooling
 .agents
+
+# Project-local knowledge base (never commit or sync)
+knowledge-base/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,9 @@
 
 ## Project-specific agent rule
 
-- Do not use Stefania, its skills, Wiki, knowledge base, memory, or related workflows for this project.
+- Use only the project-local knowledge base in `knowledge-base/`.
+- Reading and writing this local knowledge base is allowed, but its contents must never be staged, committed, pushed, synchronized, uploaded, or copied to any remote surface.
+- Do not use Stefania Wiki, DataCatalog, remote knowledge-base adapters, cross-project memory, or knowledge-base sync workflows for this project.
 - Work only with the repository and task-specific tools explicitly requested by the user.
 
 ## Stack


### PR DESCRIPTION
## Что изменено

- разрешена только локальная база знаний проекта в `knowledge-base/`
- запрещены Wiki, DataCatalog, remote adapters, sync и upload
- `knowledge-base/` добавлена в gitignore, поэтому содержимое не попадёт в commit или push

Содержимое локальной базы знаний в PR отсутствует.