### PR TITLE
fix: allow staging lead retry invoker

### DIFF
--- a/docs/staging-environment.md
+++ b/docs/staging-environment.md
@@ -65,7 +65,9 @@ Fitbase credentials в окружение fixture-функции.
 1. Serverless YDB `zvenfit-leads-staging` с deletion protection.
 2. Runtime SA lead function с `ydb.editor` только на staging YDB.
 3. Gateway SA с `storage.viewer` на staging bucket и
-   `functions.functionInvoker` на lead, schedule и authorizer functions.
+   `functions.functionInvoker` на lead, schedule и authorizer functions. Lead
+   Runtime SA также получает `functions.functionInvoker` только на lead-функцию,
+   чтобы retry-trigger мог обработать очередь.
 4. Deploy SA с `functions.editor`, `api-gateway.editor` и resource-scoped
    YDB/S3 permissions только в staging folder.
 5. Три приватные Cloud Functions без binding `allUsers`:
@@ -127,7 +129,8 @@ Staging schedule-функция использует динамический `f
 - GitHub Environment содержит только staging credentials;
 - `staging.zvenfit.ru` указывает только на API Gateway;
 - bucket приватный и static website hosting выключен;
-- функции не содержат `allUsers`, Gateway SA имеет точечный invoker binding;
+- функции не содержат `allUsers`: Gateway SA имеет точечные invoker bindings,
+  а Lead Runtime SA — дополнительный binding только на lead-функцию;
 - authorizer credentials заданы только в staging Environment;
 - Telegram bot/chat не используются менеджерами;
 - staging wrapper содержит `schedule_provider: fixture`;

--- a/scripts/__tests__/staging-gateway.test.cjs
+++ b/scripts/__tests__/staging-gateway.test.cjs
@@ -83,7 +83,7 @@ function verify(mode, bindings, serviceAccountId = '') {
   });
 }
 
-test('gateway function policy requires its service account and rejects allUsers', () => {
+test('gateway function policy accepts only the explicitly allowed service accounts', () => {
   const privateBindings = [
     {
       role_id: 'functions.functionInvoker',
@@ -92,6 +92,16 @@ test('gateway function policy requires its service account and rejects allUsers'
   ];
   assert.equal(verify('gateway', privateBindings, 'gateway-sa').status, 0);
   assert.equal(verify('gateway', privateBindings, 'wrong-sa').status, 1);
+
+  const leadBindings = [
+    ...privateBindings,
+    {
+      role_id: 'functions.functionInvoker',
+      subject: { type: 'serviceAccount', id: 'lead-runtime-sa' },
+    },
+  ];
+  assert.equal(verify('gateway', leadBindings, 'gateway-sa,lead-runtime-sa').status, 0);
+  assert.equal(verify('gateway', leadBindings, 'gateway-sa').status, 1);
 
   const publicBindings = [
     {
@@ -103,13 +113,13 @@ test('gateway function policy requires its service account and rejects allUsers'
   assert.equal(verify('public', publicBindings).status, 0);
 
   const extraInvoker = [
-    ...privateBindings,
+    ...leadBindings,
     {
       role_id: 'functions.functionInvoker',
       subject: { type: 'serviceAccount', id: 'unrelated-sa' },
     },
   ];
-  assert.equal(verify('gateway', extraInvoker, 'gateway-sa').status, 1);
+  assert.equal(verify('gateway', extraInvoker, 'gateway-sa,lead-runtime-sa').status, 1);
 });
 
 test('Basic credential hash accepts only an unambiguous high-entropy ASCII pair', () => {

--- a/scripts/deploy-lead-intake.sh
+++ b/scripts/deploy-lead-intake.sh
@@ -116,7 +116,9 @@ if ! yc serverless function get --name="${FUNCTION_NAME}" >/dev/null 2>&1; then
 fi
 
 if ! yc serverless function list-access-bindings --name="${FUNCTION_NAME}" --format=json |
-  node "${ROOT_DIR}/scripts/verify-function-invoker.cjs" "${FUNCTION_INVOKER_MODE}" "${GATEWAY_SERVICE_ACCOUNT_ID}"; then
+  node "${ROOT_DIR}/scripts/verify-function-invoker.cjs" \
+    "${FUNCTION_INVOKER_MODE}" \
+    "${GATEWAY_SERVICE_ACCOUNT_ID},${YC_LEAD_SERVICE_ACCOUNT_ID}"; then
   echo "deploy-lead-intake: ${FUNCTION_NAME} has an invalid ${FUNCTION_INVOKER_MODE} functionInvoker policy" >&2
   echo "Provision the required binding with an admin identity before deploy" >&2
   exit 1

--- a/scripts/verify-function-invoker.cjs
+++ b/scripts/verify-function-invoker.cjs
@@ -3,7 +3,10 @@
 const fs = require('node:fs');
 
 const mode = process.argv[2];
-const serviceAccountId = process.argv[3] || '';
+const serviceAccountIds = (process.argv[3] || '')
+  .split(',')
+  .map(value => value.trim())
+  .filter(Boolean);
 const bindings = JSON.parse(fs.readFileSync(0, 'utf8'));
 
 if (!Array.isArray(bindings)) {
@@ -23,21 +26,22 @@ if (mode === 'public') {
 }
 
 if (mode === 'gateway') {
-  if (!serviceAccountId) {
-    throw new Error('verify-function-invoker: gateway service account id is required');
+  if (serviceAccountIds.length === 0) {
+    throw new Error('verify-function-invoker: at least one allowed service account id is required');
   }
   if (hasPublicInvoker) {
     throw new Error('verify-function-invoker: staging function must not allow allUsers');
   }
 
-  const gatewayCanInvoke = invokers.some(
-    binding => binding.subject?.type === 'serviceAccount' && binding.subject?.id === serviceAccountId,
+  const allowedInvokerIds = new Set(serviceAccountIds);
+  const everyAllowedAccountCanInvoke = serviceAccountIds.every(serviceAccountId =>
+    invokers.some(binding => binding.subject?.type === 'serviceAccount' && binding.subject?.id === serviceAccountId),
   );
-  if (!gatewayCanInvoke) {
-    throw new Error('verify-function-invoker: gateway service account binding is missing');
+  if (!everyAllowedAccountCanInvoke) {
+    throw new Error('verify-function-invoker: an allowed service account binding is missing');
   }
   const unexpectedInvoker = invokers.some(
-    binding => binding.subject?.type !== 'serviceAccount' || binding.subject?.id !== serviceAccountId,
+    binding => binding.subject?.type !== 'serviceAccount' || !allowedInvokerIds.has(binding.subject?.id),
   );
   if (unexpectedInvoker) {
     throw new Error('verify-function-invoker: unexpected functionInvoker binding is present');


### PR DESCRIPTION
## Исправление

Staging lead-функция вызывается не только API Gateway, но и timer retry-trigger от Lead Runtime SA. Строгая IAM-проверка теперь принимает явный allowlist из двух SA для lead и по-прежнему отклоняет allUsers и любые посторонние invoker bindings. Schedule и authorizer остаются доступны только Gateway SA.

## Проверено

- 54 deployment/script tests
- lint:public
- bash syntax
- diff check