### PR TITLE
chore: harden frontend deployment identity

### DIFF
--- a/.github/workflows/_deploy-environment.yml
+++ b/.github/workflows/_deploy-environment.yml
@@ -65,7 +65,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 env:
   NODE_VERSION: '22'
@@ -151,6 +150,9 @@ jobs:
     needs: [validate-config, quality-checks]
     runs-on: ubuntu-latest
     environment: ${{ inputs.deployment_environment }}
+    permissions:
+      contents: read
+      id-token: write
     outputs:
       function_url: ${{ steps.get-url.outputs.url }}
       function_id: ${{ steps.get-url.outputs.id }}
@@ -240,6 +242,9 @@ jobs:
     needs: [validate-config, quality-checks]
     runs-on: ubuntu-latest
     environment: ${{ inputs.deployment_environment }}
+    permissions:
+      contents: read
+      id-token: write
     outputs:
       function_url: ${{ steps.get-schedule-url.outputs.url }}
       function_id: ${{ steps.get-schedule-url.outputs.id }}
@@ -304,6 +309,9 @@ jobs:
     needs: [validate-config, quality-checks]
     runs-on: ubuntu-latest
     environment: ${{ inputs.deployment_environment }}
+    permissions:
+      contents: read
+      id-token: write
     outputs:
       function_url: ${{ steps.get-traffic-url.outputs.url }}
       function_id: ${{ steps.get-traffic-url.outputs.id }}
@@ -365,6 +373,9 @@ jobs:
     needs: [validate-config, quality-checks]
     runs-on: ubuntu-latest
     environment: ${{ inputs.deployment_environment }}
+    permissions:
+      contents: read
+      id-token: write
     outputs:
       function_id: ${{ steps.get-authorizer-id.outputs.id }}
       previous_version_id: ${{ steps.deploy-authorizer.outputs.previous_version_id }}
@@ -431,6 +442,9 @@ jobs:
     needs: [validate-config, deploy-function, deploy-schedule-function, deploy-traffic-function, deploy-authorizer]
     runs-on: ubuntu-latest
     environment: ${{ inputs.deployment_environment }}
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Checkout repository
@@ -591,6 +605,9 @@ jobs:
           needs.deploy-authorizer.result == 'success' && needs.deploy-site.result != 'success' }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.deployment_environment }}
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Checkout repository

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -48,6 +48,9 @@ yc config get folder-id
 ```
 
 Не создавай authorized JSON key для GitHub Actions. Deployment использует WIF.
+Production deploy identity называется `zvenfit-frontend-ci-sa`: application
+namespace в имени обязателен, потому что folder также содержит Estetika и
+reminder. GitHub хранит только неизменяемый service account ID.
 
 ## GitHub OIDC / WIF
 
@@ -75,7 +78,9 @@ yc iam workload-identity federated-credential create \
 Job получает OIDC JWT, обменивает его на короткоживущий IAM token и выпускает
 одночасовой ephemeral Object Storage key с session policy только для bucket
 выбранного environment. Постоянные `YC_SA_JSON_KEY`,
-`YC_ACCESS_KEY_ID` и `YC_SECRET_ACCESS_KEY` workflow не читает.
+`YC_ACCESS_KEY_ID` и `YC_SECRET_ACCESS_KEY` workflow не читает. После перехода
+на WIF эти GitHub Secrets и соответствующие authorized/access keys должны быть
+отозваны, а не оставлены как запасной путь.
 
 ## GitHub Environments
 
@@ -122,6 +127,8 @@ Staging не получает Fitbase, Telegram, Monium или production creden
 Важные границы:
 
 - deploy SA может менять версии только своих Functions и spec своего Gateway;
+- в общей production folder роли `functions.editor` и `ydb.editor` назначаются
+  на конкретные ресурсы, а не на folder целиком;
 - runtime lead SA имеет доступ только к своей YDB;
 - Gateway SA только читает свой bucket и вызывает свои Functions;
 - retry trigger создаётся/обновляется bootstrap-процессом, не обычным CI;

--- a/scripts/__tests__/deploy-lead-intake.test.cjs
+++ b/scripts/__tests__/deploy-lead-intake.test.cjs
@@ -187,6 +187,35 @@ test('traffic deploy remains stateless and carries no paid secret or storage cha
 
 test('deploy jobs use OIDC and ephemeral storage keys instead of long-lived cloud credentials', () => {
   assert.match(reusableWorkflow, /id-token: write/);
+  assert.doesNotMatch(reusableWorkflow, /^  id-token: write$/m);
+  assert.equal((reusableWorkflow.match(/^      id-token: write$/gm) || []).length, 6);
+
+  for (const jobName of [
+    'deploy-function',
+    'deploy-schedule-function',
+    'deploy-traffic-function',
+    'deploy-authorizer',
+    'deploy-site',
+    'rollback-staging-authorizer',
+  ]) {
+    assert.match(
+      reusableWorkflow,
+      new RegExp(
+        `  ${jobName}:\\n[\\s\\S]*?    permissions:\\n      contents: read\\n      id-token: write`,
+      ),
+    );
+  }
+
+  for (const jobName of ['validate-config', 'quality-checks']) {
+    const jobStart = reusableWorkflow.indexOf(`  ${jobName}:`);
+    const nextJob = reusableWorkflow.slice(jobStart + 1).search(/\n  [a-z0-9-]+:\n/);
+    const jobBlock = reusableWorkflow.slice(
+      jobStart,
+      nextJob === -1 ? reusableWorkflow.length : jobStart + 1 + nextJob,
+    );
+    assert.doesNotMatch(jobBlock, /id-token: write/);
+  }
+
   assert.match(reusableWorkflow, /bash scripts\/auth-yc-wif\.sh/);
   assert.match(reusableWorkflow, /bash scripts\/issue-ephemeral-storage-key\.sh/);
   assert.match(reusableWorkflow, /OBJECT_STORAGE_BUCKET: \$\{\{ inputs\.s3_bucket \}\}/);


### PR DESCRIPTION
## Что изменено
- OIDC token доступен только deploy/rollback jobs
- задокументирован `zvenfit-frontend-ci-sa` и обязательный WIF-only режим
- добавлен контракт least-privilege permissions

## Live IAM
- deploy SA переименован без изменения ID/WIF
- folder-wide `functions.editor` и `ydb.viewer` заменены точечными bindings

## Проверки
- `npm run lint`
- `npm run lint:public`
- deploy workflow contract: 20/20
- monitoring contract: 23/23
- `npm run test:build`