### PR TITLE
fix: resolve deploy database by resource id

### DIFF
--- a/.github/workflows/_deploy-environment.yml
+++ b/.github/workflows/_deploy-environment.yml
@@ -186,6 +186,7 @@ jobs:
           YC_FOLDER_ID: ${{ vars.YC_FOLDER_ID }}
           YC_LEAD_FUNCTION_NAME: ${{ inputs.lead_function_name }}
           YC_LEAD_RETRY_TRIGGER_NAME: ${{ inputs.lead_retry_trigger_name }}
+          YDB_DATABASE_ID: ${{ vars.YDB_DATABASE_ID }}
           YDB_DATABASE_NAME: ${{ inputs.ydb_database_name }}
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -99,6 +99,7 @@ Environment variables:
 | `YC_FOLDER_ID` | production folder | staging folder |
 | `YC_DEPLOY_SERVICE_ACCOUNT_ID` | production deploy SA | staging deploy SA |
 | `YC_LEAD_SERVICE_ACCOUNT_ID` | production runtime SA | staging runtime SA |
+| `YDB_DATABASE_ID` | production lead database ID | staging lead database ID |
 | `YC_GATEWAY_SERVICE_ACCOUNT_ID` | — | staging Gateway SA |
 | `YC_SWS_SECURITY_PROFILE_ID` | — | staging SWS profile |
 | `Y_MAPS_API_KEY` | browser maps key | browser maps key |
@@ -129,6 +130,8 @@ Staging не получает Fitbase, Telegram, Monium или production creden
 - deploy SA может менять версии только своих Functions и spec своего Gateway;
 - в общей production folder роли `functions.editor` и `ydb.editor` назначаются
   на конкретные ресурсы, а не на folder целиком;
+- CI получает YDB по `YDB_DATABASE_ID`, поэтому ему не нужна folder-level роль
+  `ydb.viewer`; lookup по имени остаётся только локальным fallback;
 - runtime lead SA имеет доступ только к своей YDB;
 - Gateway SA только читает свой bucket и вызывает свои Functions;
 - retry trigger создаётся/обновляется bootstrap-процессом, не обычным CI;

--- a/scripts/__tests__/deploy-lead-intake.test.cjs
+++ b/scripts/__tests__/deploy-lead-intake.test.cjs
@@ -102,6 +102,7 @@ test('reusable workflow passes resource identities explicitly instead of using p
   assert.match(reusableWorkflow, /YC_SCHEDULE_FUNCTION_NAME: \$\{\{ inputs\.schedule_function_name \}\}/);
   assert.match(reusableWorkflow, /YC_TRAFFIC_FUNCTION_NAME: \$\{\{ inputs\.traffic_function_name \}\}/);
   assert.match(reusableWorkflow, /YDB_DATABASE_NAME: \$\{\{ inputs\.ydb_database_name \}\}/);
+  assert.match(reusableWorkflow, /YDB_DATABASE_ID: \$\{\{ vars\.YDB_DATABASE_ID \}\}/);
   assert.match(reusableWorkflow, /s3:\/\/\$\{\{ inputs\.s3_bucket \}\}/);
   assert.doesNotMatch(reusableWorkflow, /zvenfit-telegram-lead(?:\n|'|")/);
   assert.doesNotMatch(reusableWorkflow, /zvenfit-fitbase-schedule(?:\n|'|")/);
@@ -283,6 +284,9 @@ test('staging uses isolated artifacts instead of runtime provider switches and k
 
 test('regular deploy requires a pre-provisioned database', () => {
   assert.match(deployScript, /must be provisioned before CI deploy/);
+  assert.match(deployScript, /set YDB_DATABASE_ID for resource-scoped CI access/);
+  assert.match(deployScript, /YDB_DATABASE_GET_ARGS=\(--id="\$\{YDB_DATABASE_ID\}"\)/);
+  assert.match(deployScript, /yc ydb database get "\$\{YDB_DATABASE_GET_ARGS\[@\]\}"/);
   assert.doesNotMatch(deployScript, /^\s*yc ydb database create/m);
 });
 

--- a/scripts/deploy-lead-intake.sh
+++ b/scripts/deploy-lead-intake.sh
@@ -6,6 +6,7 @@ SOURCE_DIR="$(mktemp -d /tmp/zvenfit-lead.XXXXXX)"
 trap 'rm -rf -- "${SOURCE_DIR}"' EXIT
 FUNCTION_NAME="${YC_LEAD_FUNCTION_NAME:-zvenfit-telegram-lead}"
 TRIGGER_NAME="${YC_LEAD_RETRY_TRIGGER_NAME:-zvenfit-lead-telegram-retry}"
+YDB_DATABASE_ID="${YDB_DATABASE_ID:-}"
 YDB_DATABASE_NAME="${YDB_DATABASE_NAME:-zvenfit-leads}"
 YDB_LEADS_TABLE="${YDB_LEADS_TABLE:-leads}"
 YDB_RATE_LIMITS_TABLE="${YDB_RATE_LIMITS_TABLE:-lead_rate_limits}"
@@ -105,12 +106,24 @@ fi
 yc config set folder-id "${YC_FOLDER_ID}" >/dev/null
 
 if [[ -z "${YDB_CONNECTION_STRING:-}" ]]; then
-  if ! yc ydb database get --name="${YDB_DATABASE_NAME}" >/dev/null 2>&1; then
-    echo "deploy-lead-intake: YDB database ${YDB_DATABASE_NAME} must be provisioned before CI deploy" >&2
+  if [[ "${GITHUB_ACTIONS:-}" == "true" && -z "${YDB_DATABASE_ID}" ]]; then
+    echo "deploy-lead-intake: set YDB_DATABASE_ID for resource-scoped CI access" >&2
     exit 1
   fi
 
-  YDB_CONNECTION_STRING="$(yc ydb database get --name="${YDB_DATABASE_NAME}" --format=json | node -e "
+  YDB_DATABASE_GET_ARGS=(--name="${YDB_DATABASE_NAME}")
+  YDB_DATABASE_REFERENCE="${YDB_DATABASE_NAME}"
+  if [[ -n "${YDB_DATABASE_ID}" ]]; then
+    YDB_DATABASE_GET_ARGS=(--id="${YDB_DATABASE_ID}")
+    YDB_DATABASE_REFERENCE="${YDB_DATABASE_ID}"
+  fi
+
+  if ! yc ydb database get "${YDB_DATABASE_GET_ARGS[@]}" >/dev/null 2>&1; then
+    echo "deploy-lead-intake: YDB database ${YDB_DATABASE_REFERENCE} must be provisioned before CI deploy" >&2
+    exit 1
+  fi
+
+  YDB_CONNECTION_STRING="$(yc ydb database get "${YDB_DATABASE_GET_ARGS[@]}" --format=json | node -e "
 const fs = require('fs');
 const data = JSON.parse(fs.readFileSync(0, 'utf8'));
 process.stdout.write(data.endpoint || '');


### PR DESCRIPTION
## Причина
После снятия folder-level `ydb.viewer` lead deploy не мог разрешить базу по имени.

## Исправление
- production/staging CI получают `YDB_DATABASE_ID` из GitHub Environment variable
- deploy использует `yc ydb database get --id`
- lookup по имени оставлен только для локального запуска
- folder-level `ydb.viewer` не возвращается

## Проверки
- `bash -n scripts/deploy-lead-intake.sh`
- deploy workflow contract: 20/20
- `npm run lint`
- `npm run lint:public`
- `npm run test:build`