### PR TITLE
docs: clarify project logs and KB policy

### DIFF
--- a/docs/monitoring-operations.md
+++ b/docs/monitoring-operations.md
@@ -63,6 +63,13 @@ Production channels: `ZvenFit · production · Telegram` и
 `ZvenFit · production · Email`. Raw logs хранятся три дня. Для более старого
 инцидента сначала используются alert history, notification feed и metric series.
 
+Если раздел Logs открыт только с `project=folder__b1ge1e4iopttj79hfdfm`,
+Monium не выполняет запрос и показывает пустой экран: для raw logs обязательна
+метка `service`. Сначала добавь `service=default` и выполни запрос, затем сузь
+результат по `meta.application`, `meta.environment`, `meta.service`,
+`resource_id`, `meta.event` или `level`. Пустая таблица после выполненного
+полного селектора уже означает отсутствие подходящих записей в выбранном окне.
+
 ## Desired-state drift
 
 Все шестнадцать alerts хранят человекочитаемые названия и taxonomy labels в
@@ -166,5 +173,6 @@ delay, затем desired state, тесты и live drift.
 - Deploy marker не добавляется без отдельного write-path: у deploy SA нет metric
   writer, а расширять использование runtime `MONIUM_API_KEY` на CI нельзя молча.
 - Любое изменение KB проверяется на секреты и персональные данные до коммита.
-- Project KB хранится только локально в `knowledge-base/` и не коммитится, не
-  публикуется и не синхронизируется с удалёнными KB-системами.
+- Project KB в `knowledge-base/` — version-controlled документация: она
+  коммитится и публикуется только в настроенный Git remote этого проекта.
+  Отдельная синхронизация в Wiki, DataCatalog или другие KB-системы запрещена.

--- a/knowledge-base/monitoring-runbook.md
+++ b/knowledge-base/monitoring-runbook.md
@@ -1,7 +1,7 @@
 ---
 type: runbook
 title: ZvenFit alerts, metrics and logs runbook
-updated: 2026-08-15
+updated: 2026-08-16
 ---
 
 # Alerts, metrics and logs runbook
@@ -22,6 +22,30 @@ is the project entry point and intentionally does not duplicate every selector.
 - CDN query masking remains out of scope while no separate raw CDN pipeline is created.
 - Production smoke uses only synthetic non-personal records and requires explicit confirmation.
 
+## Raw logs
+
+- Open `https://monium.yandex.cloud/projects/folder__b1ge1e4iopttj79hfdfm/logs`.
+- `project` alone is not an executable raw-log query in Monium. Add the required
+  `service=default` label and run the query.
+- Then isolate this project with `meta.application=zvenfit-frontend` and
+  `meta.environment=production`; add `meta.service`, `resource_id`, `meta.event`,
+  or `level` only when narrowing an incident.
+- If the UI still says “select service”, the query has not run. If a complete
+  query ran and the table is empty, expand the time range up to the three-day
+  raw-log retention window.
+
+### Quick access
+
+- [Recent production application events (INFO, one hour)][logs-info]
+- [Recent production application errors (ERROR, one hour)][logs-error]
+
+Keep these two shared links as the canonical entry points instead of maintaining
+many narrowly scoped saved searches. During an incident, open the relevant link,
+set the alert time window including its evaluation delay, then add exactly one
+or two narrowing labels: `meta.service`, `resource_id`, `meta.event`,
+`meta.request_id`, or `meta.error_code`. Browser bookmarks are convenient for
+personal access, but the Git-tracked links are the shared source of truth.
+
 ## Incident path
 
 1. Open the alert and capture `service`, `resource_id`, window, and delay.
@@ -29,3 +53,6 @@ is the project entry point and intentionally does not duplicate every selector.
 3. Search raw logs by component and narrow by event/request/error fields.
 4. Inspect the source log metric or direct/platform series.
 5. Confirm the later `OK` transition and delivery to both notification methods.
+
+[logs-info]: https://monium.yandex.cloud/projects/folder__b1ge1e4iopttj79hfdfm/logs?tab=logs&queries=NobwRAdghgtgpmAXGAgmANGAblANgVwWRAAcAnAewCs4BjAFwAIBeRgHTADMLcATOMgH1BAIwCMAczhi4AFgCWFEvXpUA7AE4AFp16cYHdIwDOArPNpwW7MP05R8ueoca44WOLmscAkgDkAMQB5F3h6KAA6KBISXAsoekUIbzAALw8ITnl6AFpOSgh6OAheULhwiOLzAvhClPIKXnwGJI4AXwwwLXlefggke1xTTF55YygRN14BvGGwIoAPegBZRqJB0zaAXSA&from=now-1h&to=now&columns=level%2Ctime%2Cmessage%2Chost&groupByField=level&chartType=column&linesMode=single&refresh=off&grepContext=%7Bproject%20%3D%20%22%22%2C%20cluster%20%3D%20%22%22%2C%20service%20%3D%20%22%22%2C%20host%20%3D%20%22%22%2C%20resource_id%20%3D%20%22%22%7D
+[logs-error]: https://monium.yandex.cloud/projects/folder__b1ge1e4iopttj79hfdfm/logs?tab=logs&queries=NobwRAdghgtgpmAXGAgmANGAblANgVwWRAAcAnAewCs4BjAFwAIBeRgHTADMLcATOMgH1BAIwCMAczhi4AFgCWFEvXpUA7AE4AFp16cYHdIwDOArPNpwW7MP05R8ueoca44WOLmscAogCU-AHk-F3h6KAA6KBISXAsoekUIbzAALw8ITnl6AFpOSgh6OAheULhwiOLzAvhClPIKXnwGJI4AXwwwLXlefggke1xTTF55YygRN14BvGGwIoAPegBZRqJB0zaAXSA&from=now-1h&to=now&columns=level%2Ctime%2Cmessage%2Chost&groupByField=level&chartType=column&linesMode=single&refresh=off&grepContext=%7Bproject%20%3D%20%22%22%2C%20cluster%20%3D%20%22%22%2C%20service%20%3D%20%22%22%2C%20host%20%3D%20%22%22%2C%20resource_id%20%3D%20%22%22%7D


### PR DESCRIPTION
## Summary
- document why Monium Logs is empty without service=default
- keep the project KB version-controlled in this repository
- add canonical INFO and ERROR deep links for production logs

## Verification
- npm run test:monitoring (29/29)
- git diff --check