### PR TITLE
docs: track dashboard log shortcuts

### DIFF
--- a/docs/monitoring-operations.md
+++ b/docs/monitoring-operations.md
@@ -52,6 +52,7 @@ reusable deploy workflow передаёт их явно. Изменение sele
 | Вопрос | Раздел Monium |
 | --- | --- |
 | Что сломано сейчас | [Dashboard `ZvenFit · production`](https://monium.yandex.cloud/projects/folder__b1ge1e4iopttj79hfdfm/dashboards/zvenfit-production-monitoring) |
+| Быстро открыть production-логи | Ссылки `INFO за час` и `ERROR за час` в первой строке dashboard; канонические URL — в [project runbook](../knowledge-base/monitoring-runbook.md#quick-access) |
 | Какой alert сработал и для какой функции | [Alerts](https://monium.yandex.cloud/projects/folder__b1ge1e4iopttj79hfdfm/alerts) |
 | Какие уведомления реально отправились | [Notification feed](https://monium.yandex.cloud/projects/folder__b1ge1e4iopttj79hfdfm/notification-feed) |
 | Почему сработал application alert | [Raw logs](https://monium.yandex.cloud/projects/folder__b1ge1e4iopttj79hfdfm/logs) |

--- a/knowledge-base/dashboards.md
+++ b/knowledge-base/dashboards.md
@@ -1,7 +1,7 @@
 ---
 type: dashboard
 title: ZvenFit production monitoring
-updated: 2026-08-15
+updated: 2026-08-16
 ---
 
 # Production monitoring dashboard
@@ -9,6 +9,9 @@ updated: 2026-08-15
 - URL: https://monium.yandex.cloud/projects/folder__b1ge1e4iopttj79hfdfm/dashboards/zvenfit-production-monitoring
 - Purpose: production lead pipeline, Telegram delivery, Fitbase schedule, Cloud Functions, traffic, and YDB health.
 - Reading order: alert statuses, Telegram queue and heartbeat, then application and Cloud Functions diagnostics.
+- The first row contains one-click `INFO за час` and `ERROR за час` links to
+  production application logs. The same canonical URLs are tracked in the
+  monitoring runbook.
 - Empty event graphs are normal while the corresponding alert is green.
 - Refresh interval: one minute.
 

--- a/knowledge-base/monitoring-runbook.md
+++ b/knowledge-base/monitoring-runbook.md
@@ -39,6 +39,9 @@ is the project entry point and intentionally does not duplicate every selector.
 - [Recent production application events (INFO, one hour)][logs-info]
 - [Recent production application errors (ERROR, one hour)][logs-error]
 
+The same two links are available in the full-width first row of the production
+dashboard, so an incident can be opened from the board without returning to Git.
+
 Keep these two shared links as the canonical entry points instead of maintaining
 many narrowly scoped saved searches. During an incident, open the relevant link,
 set the alert time window including its evaluation delay, then add exactly one
@@ -54,5 +57,5 @@ personal access, but the Git-tracked links are the shared source of truth.
 4. Inspect the source log metric or direct/platform series.
 5. Confirm the later `OK` transition and delivery to both notification methods.
 
-[logs-info]: https://monium.yandex.cloud/projects/folder__b1ge1e4iopttj79hfdfm/logs?tab=logs&queries=NobwRAdghgtgpmAXGAgmANGAblANgVwWRAAcAnAewCs4BjAFwAIBeRgHTADMLcATOMgH1BAIwCMAczhi4AFgCWFEvXpUA7AE4AFp16cYHdIwDOArPNpwW7MP05R8ueoca44WOLmscAkgDkAMQB5F3h6KAA6KBISXAsoekUIbzAALw8ITnl6AFpOSgh6OAheULhwiOLzAvhClPIKXnwGJI4AXwwwLXlefggke1xTTF55YygRN14BvGGwIoAPegBZRqJB0zaAXSA&from=now-1h&to=now&columns=level%2Ctime%2Cmessage%2Chost&groupByField=level&chartType=column&linesMode=single&refresh=off&grepContext=%7Bproject%20%3D%20%22%22%2C%20cluster%20%3D%20%22%22%2C%20service%20%3D%20%22%22%2C%20host%20%3D%20%22%22%2C%20resource_id%20%3D%20%22%22%7D
-[logs-error]: https://monium.yandex.cloud/projects/folder__b1ge1e4iopttj79hfdfm/logs?tab=logs&queries=NobwRAdghgtgpmAXGAgmANGAblANgVwWRAAcAnAewCs4BjAFwAIBeRgHTADMLcATOMgH1BAIwCMAczhi4AFgCWFEvXpUA7AE4AFp16cYHdIwDOArPNpwW7MP05R8ueoca44WOLmscAogCU-AHk-F3h6KAA6KBISXAsoekUIbzAALw8ITnl6AFpOSgh6OAheULhwiOLzAvhClPIKXnwGJI4AXwwwLXlefggke1xTTF55YygRN14BvGGwIoAPegBZRqJB0zaAXSA&from=now-1h&to=now&columns=level%2Ctime%2Cmessage%2Chost&groupByField=level&chartType=column&linesMode=single&refresh=off&grepContext=%7Bproject%20%3D%20%22%22%2C%20cluster%20%3D%20%22%22%2C%20service%20%3D%20%22%22%2C%20host%20%3D%20%22%22%2C%20resource_id%20%3D%20%22%22%7D
+[logs-info]: https://monium.yandex.cloud/projects/folder__b1ge1e4iopttj79hfdfm/logs?tab=logs&queries=NobwRAdghgtgpmAXGAgmANGAblANgVwWRAAcAnAewCs4BjAFwAIBeRgHTADMLcATOMgH1BAIwCMAczhi4AFgCWFEvXpUA7AE4AFp16cYHdIwDOArPNpwW7MP05R8ueoca44WOLmscAkgDkAMQB5F3h6KAA6KBISXAsoekUIbzAALw8ITnl6AFpOSgh6OAheULhwiOLzAvhClPIKXnwGJI4AXwwwLXlefggke1xTTF55YygRN14BvGGwIoAPegBZRqJB0zaAXSA&from=now-1h&to=now&columns=level%2Ctime%2Cmessage%2Chost&groupByField=level&chartType=column&linesMode=single&refresh=off
+[logs-error]: https://monium.yandex.cloud/projects/folder__b1ge1e4iopttj79hfdfm/logs?tab=logs&queries=NobwRAdghgtgpmAXGAgmANGAblANgVwWRAAcAnAewCs4BjAFwAIBeRgHTADMLcATOMgH1BAIwCMAczhi4AFgCWFEvXpUA7AE4AFp16cYHdIwDOArPNpwW7MP05R8ueoca44WOLmscAogCU-AHk-F3h6KAA6KBISXAsoekUIbzAALw8ITnl6AFpOSgh6OAheULhwiOLzAvhClPIKXnwGJI4AXwwwLXlefggke1xTTF55YygRN14BvGGwIoAPegBZRqJB0zaAXSA&from=now-1h&to=now&columns=level%2Ctime%2Cmessage%2Chost&groupByField=level&chartType=column&linesMode=single&refresh=off

--- a/scripts/__tests__/monitoring-config.test.cjs
+++ b/scripts/__tests__/monitoring-config.test.cjs
@@ -20,6 +20,7 @@ const source = [
   .map(file => fs.readFileSync(path.join(ROOT, file), 'utf8'))
   .join('\n');
 const monitoringDocs = fs.readFileSync(path.join(ROOT, 'docs/monitoring.md'), 'utf8');
+const monitoringRunbook = fs.readFileSync(path.join(ROOT, 'knowledge-base/monitoring-runbook.md'), 'utf8');
 const smokeScript = fs.readFileSync(path.join(ROOT, 'scripts/test-monitoring-alerts.sh'), 'utf8');
 const directMetricsSource = [
   'functions/lead-intake/src/handler.ts',
@@ -28,6 +29,34 @@ const directMetricsSource = [
 ]
   .map(file => fs.readFileSync(path.join(ROOT, file), 'utf8'))
   .join('\n');
+
+test('dashboard exposes the canonical one-hour INFO and ERROR log links', () => {
+  const quickAccess = config.dashboard.quickLogAccess;
+
+  assert.equal(quickAccess.title, 'Быстрый доступ к логам');
+  assert.equal(quickAccess.position, 'top');
+  assert.deepEqual(quickAccess.layout, { widthColumns: 36, heightRows: 2 });
+  assert.deepEqual(
+    quickAccess.links.map(({ label, level, window }) => ({ label, level, window })),
+    [
+      { label: 'INFO за час', level: 'INFO', window: '1h' },
+      { label: 'ERROR за час', level: 'ERROR', window: '1h' },
+    ],
+  );
+
+  for (const link of quickAccess.links) {
+    const url = new URL(link.url);
+
+    assert.equal(url.hostname, 'monium.yandex.cloud');
+    assert.equal(url.pathname, `/projects/${config.project}/logs`);
+    assert.ok(url.searchParams.get('queries'), `${link.label} has no encoded log query`);
+    assert.equal(url.searchParams.get('from'), 'now-1h');
+    assert.equal(url.searchParams.get('to'), 'now');
+    assert.ok(monitoringRunbook.includes(link.url), `${link.label} is not tracked in the project runbook`);
+  }
+
+  assert.notEqual(quickAccess.links[0].url, quickAccess.links[1].url);
+});
 
 test('every monitored event exists in application code and documentation', () => {
   for (const metric of config.logMetrics) {

--- a/scripts/monitoring.config.json
+++ b/scripts/monitoring.config.json
@@ -58,6 +58,28 @@
     }
   },
   "dashboard": {
+    "quickLogAccess": {
+      "title": "Быстрый доступ к логам",
+      "position": "top",
+      "layout": {
+        "widthColumns": 36,
+        "heightRows": 2
+      },
+      "links": [
+        {
+          "label": "INFO за час",
+          "level": "INFO",
+          "window": "1h",
+          "url": "https://monium.yandex.cloud/projects/folder__b1ge1e4iopttj79hfdfm/logs?tab=logs&queries=NobwRAdghgtgpmAXGAgmANGAblANgVwWRAAcAnAewCs4BjAFwAIBeRgHTADMLcATOMgH1BAIwCMAczhi4AFgCWFEvXpUA7AE4AFp16cYHdIwDOArPNpwW7MP05R8ueoca44WOLmscAkgDkAMQB5F3h6KAA6KBISXAsoekUIbzAALw8ITnl6AFpOSgh6OAheULhwiOLzAvhClPIKXnwGJI4AXwwwLXlefggke1xTTF55YygRN14BvGGwIoAPegBZRqJB0zaAXSA&from=now-1h&to=now&columns=level%2Ctime%2Cmessage%2Chost&groupByField=level&chartType=column&linesMode=single&refresh=off"
+        },
+        {
+          "label": "ERROR за час",
+          "level": "ERROR",
+          "window": "1h",
+          "url": "https://monium.yandex.cloud/projects/folder__b1ge1e4iopttj79hfdfm/logs?tab=logs&queries=NobwRAdghgtgpmAXGAgmANGAblANgVwWRAAcAnAewCs4BjAFwAIBeRgHTADMLcATOMgH1BAIwCMAczhi4AFgCWFEvXpUA7AE4AFp16cYHdIwDOArPNpwW7MP05R8ueoca44WOLmscAogCU-AHk-F3h6KAA6KBISXAsoekUIbzAALw8ITnl6AFpOSgh6OAheULhwiOLzAvhClPIKXnwGJI4AXwwwLXlefggke1xTTF55YygRN14BvGGwIoAPegBZRqJB0zaAXSA&from=now-1h&to=now&columns=level%2Ctime%2Cmessage%2Chost&groupByField=level&chartType=column&linesMode=single&refresh=off"
+        }
+      ]
+    },
     "runtimeErrors": {
       "title": "Ошибки Cloud Functions",
       "metricSelector": "{project=\"folder__b1ge1e4iopttj79hfdfm\", service=\"serverless-functions\", name=\"functions_errors\", resource_id=\"zvenfit-telegram-lead|zvenfit-fitbase-schedule|zvenfit-site-traffic\"}",


### PR DESCRIPTION
## Что сделано
- зафиксирован полноширинный верхний блок быстрых ссылок на INFO/ERROR production-логи
- синхронизированы monitoring desired state, runbook и project KB
- добавлена проверка канонических Monium URL и layout

## Проверка
- npm run test:monitoring (30/30)
- git diff --check
- обе live-ссылки открывают service=default, zvenfit-frontend, production и правильный level