### PR TITLE
chore: track native Monium dashboard JSON

### DIFF
--- a/docs/monitoring-operations.md
+++ b/docs/monitoring-operations.md
@@ -2,8 +2,10 @@
 
 Этот документ фиксирует согласованные правила эксплуатации production-monitoring
 ZvenFit. Техническое устройство метрик и ручная настройка ресурсов описаны в
-[`monitoring.md`](monitoring.md), а машиночитаемый desired state — в
-[`scripts/monitoring.config.json`](../scripts/monitoring.config.json).
+[`monitoring.md`](monitoring.md), машиночитаемый semantic desired state — в
+[`scripts/monitoring.config.json`](../scripts/monitoring.config.json), а полный
+восстанавливаемый snapshot самой борды — в
+[`scripts/monitoring.dashboard.json`](../scripts/monitoring.dashboard.json).
 
 ## Зафиксированные решения
 
@@ -74,8 +76,10 @@ Monium не выполняет запрос и показывает пустой
 ## Desired-state drift
 
 Все шестнадцать alerts хранят человекочитаемые названия и taxonomy labels в
-`scripts/monitoring.config.json`. Канонический read-only snapshot live Monium
-сравнивается с Git командой:
+`scripts/monitoring.config.json`. Полный native JSON dashboard хранится отдельно
+в `scripts/monitoring.dashboard.json`; он не содержит alerts, log metrics или
+notification channels и не является входом для drift-check. Канонический
+read-only snapshot полного набора live Monium ресурсов сравнивается с Git командой:
 
 ```bash
 npm run check:monitoring-drift -- --snapshot /path/to/monium-live.json
@@ -86,7 +90,21 @@ npm run check:monitoring-drift -- --snapshot /path/to/monium-live.json
 означает некорректный ввод. Экспорт live snapshot остаётся отдельной ручной
 read-only операцией: deploy service account не имеет folder-level viewer role,
 а private UI API не используется. Автоматизация требует отдельного согласования
-read-only IAM и поддерживаемого полного export API.
+read-only IAM и поддерживаемого полного export API для всех monitoring-ресурсов.
+
+Для самой борды поддерживается штатный путь **Настройки → JSON**:
+
+1. Для резервной копии выбрать **Без diff**, скопировать JSON и сохранить его в
+   `scripts/monitoring.dashboard.json`.
+2. Для восстановления вставить Git-версию в этот же редактор и сначала проверить
+   **Встроенный diff**.
+3. Нажимать **Применить** только для согласованного изменения live-борды.
+4. После применения повторно экспортировать сервер-нормализованный JSON, проверить
+   отсутствие секретов/персональных данных и обновить Git-файл.
+
+Monium может перегенерировать внутренние UUID элементов при import; поэтому
+источником полного layout служит последний повторный export, а смысловые ожидания
+и taxonomy по-прежнему фиксируются в `monitoring.config.json` и тестах.
 
 ## Готовые селекторы raw logs
 
@@ -169,7 +187,9 @@ delay, затем desired state, тесты и live drift.
 ## Правила изменения
 
 - Любое изменение сначала вносится в `scripts/monitoring.config.json` и
-  документацию, затем проверяется тестами и live-конфигурацией.
+  документацию, затем проверяется тестами и live-конфигурацией. Изменение самой
+  борды дополнительно завершается повторным export в
+  `scripts/monitoring.dashboard.json`.
 - Любой новый infrastructure element отдельно согласовывается с владельцем.
 - Deploy marker не добавляется без отдельного write-path: у deploy SA нет metric
   writer, а расширять использование runtime `MONIUM_API_KEY` на CI нельзя молча.

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -2,17 +2,20 @@
 
 Минимальный мониторинг production-функций. Lead/schedule logs не содержат
 персональные данные; traffic log намеренно access-like и описан отдельно ниже.
-Машиночитаемый источник конфигурации: `scripts/monitoring.config.json`.
+Машиночитаемый semantic desired state: `scripts/monitoring.config.json`.
+Полный восстанавливаемый JSON production-борды: `scripts/monitoring.dashboard.json`.
 
 Согласованные правила эксплуатации, единая taxonomy, прямые ссылки Monium,
 готовые log-селекторы и порядок разбора инцидента вынесены в
 [`monitoring-operations.md`](monitoring-operations.md).
 
 > [!IMPORTANT]
-> Log metrics, notification channels и alert rules остаются console-managed: для полного
-> набора этих ресурсов нет поддерживаемого export/import workflow в используемых публичных
-> инструментах. `scripts/monitoring.config.json` фиксирует точный desired state, а
-> `scripts/test-monitoring-alerts.sh` проверяет application log metrics синтетическими событиями.
+> Dashboard поддерживает штатный JSON export/import через **Настройки → JSON**.
+> Этот JSON охватывает только саму борду: виджеты, запросы, заголовки и layout.
+> Log metrics, notification channels и alert rules остаются console-managed, потому что
+> dashboard JSON их не содержит. `scripts/monitoring.config.json` фиксирует их точный
+> desired state, а `scripts/test-monitoring-alerts.sh` проверяет application log metrics
+> синтетическими событиями.
 > Метрики platform runtime проверяются только по реальным техническим логам: намеренно ронять
 > production-функции для теста нельзя.
 
@@ -70,7 +73,7 @@ event `site_page_view` в Cloud Logging. Monium считает page views пря
 | Metric | Что считается |
 | --- | --- |
 | `edge.requests` | Все CDN-запросы, включая HTML, assets и роботов |
-| `zvenfit_site_page_views_by_class_5m` | Валидные browser beacon events по `traffic_class` и `host` |
+| `zvenfit_site_page_views_by_class_5m` | Валидные browser beacon events по `traffic_class`; taxonomy сохраняет приложение, компонент и функцию |
 | `edge.requests_status` | Встроенная разбивка CDN по HTTP status |
 | `edge.requests_cache_status` | Встроенная разбивка CDN по cache status |
 | `edge.bytes_sent` | Встроенная скорость отдачи CDN |
@@ -89,19 +92,20 @@ edge.request_time_seconds{service="yccdn", resource="bc8rubabuwzpqqp7rifz"}
 Access-like event сохраняет IP, полный User-Agent, полный URL с query,
 referrer, `page_view_id` и признак `webdriver`. Это осознанный диагностический
 лог с общей retention Cloud Logging 3 дня. Сырые поля нельзя добавлять в labels
-метрики: grouping ограничен `traffic_class` и `host` — максимум 12 штатных
-рядов. Нормализованный `page` остаётся полем лога, потому что произвольные 404
-пути сделали бы его небезопасной высококардинальной label.
+метрики: grouping ограничен `traffic_class` и фиксированной taxonomy
+`application` / `service` / `resource_id` — четыре штатных production-ряда.
+`host` и нормализованный `page` остаются полями лога: произвольные хосты и 404
+пути сделали бы их небезопасными высококардинальными labels.
 
 Отдельного client state нет: функция не использует HMAC, Lockbox, YDB, Object
 Storage, cookies или session timeout. `page_view_id` нужен только для поиска
 повторной доставки в логах; sessions и unique visitors не считаются.
 
-Настройка функции, log-based metric и карточки **Последний page view** описана в
+Настройка функции, log-based metric и графиков page views описана в
 [`site-traffic-analytics.md`](site-traffic-analytics.md). Карточка freshness
-диагностическая, без paging-alert. Пользовательский dashboard Monium не встраивает
-raw-log строки, поэтому плитка показывает последнее значение объединённой
-пятиминутной метрики; точный timestamp события смотри в Cloud Logging.
+не используется: пользовательский dashboard Monium не встраивает raw-log строки,
+а последнее значение bucket не является временем события. Точный timestamp
+последнего `site_page_view` смотри в Cloud Logging.
 
 ## События приложения
 
@@ -461,9 +465,9 @@ bash scripts/test-monitoring-alerts.sh --confirm
 
 ## Read-only drift check
 
-`scripts/monitoring.config.json` хранит Git desired state для log metrics,
-alerts, notification channels, policy и dashboard. Снимок live-конфигурации в
-том же каноническом JSON-формате сравнивается командой:
+`scripts/monitoring.config.json` хранит semantic desired state для log metrics,
+alerts, notification channels, policy и dashboard. Снимок полного набора live-
+ресурсов в каноническом формате drift-check сравнивается командой:
 
 ```bash
 npm run check:monitoring-drift -- --snapshot /path/to/monium-live.json
@@ -478,13 +482,25 @@ labels, notification channels и структуру dashboard.
 - exit code `2` — snapshot или аргументы некорректны.
 
 Команда read-only: она не обращается к Monium самостоятельно, не меняет live
-ресурсы и не требует нового service account, IAM binding или Lockbox. Получение
-и нормализация live snapshot остаются ручным read-only шагом: deploy service
-account не имеет folder-level viewer role, а неподдерживаемый private UI API в CI
-не используется. Автоматизация возможна только после отдельного согласования
-нового read-only доступа и поддерживаемого полного export API.
+ресурсы и не требует нового service account, IAM binding или Lockbox. Нативный
+`scripts/monitoring.dashboard.json` нельзя передавать этой команде: он описывает
+только dashboard и имеет другую схему. Получение и нормализация полного live
+snapshot остаются ручным read-only шагом: deploy service account не имеет
+folder-level viewer role, а неподдерживаемый private UI API в CI не используется.
+Автоматизация возможна только после отдельного согласования нового read-only
+доступа и поддерживаемого полного export API для всех monitoring-ресурсов.
 
 ## Dashboard
+
+Канонический full-fidelity snapshot борды хранится в
+`scripts/monitoring.dashboard.json`. Он получен штатной командой Monium
+**Настройки → JSON → Без diff** и может быть вставлен в тот же диалог для
+восстановления или переноса борды. Перед **Применить** обязательно проверить
+встроенный diff: import изменяет live-борду целиком. После согласованного ручного
+изменения live-борды JSON экспортируется повторно, проверяется на секреты и
+персональные данные и коммитится вместе с соответствующим изменением
+`scripts/monitoring.config.json`. Экспорт не включает alerts, log metrics и
+notification channels.
 
 Для вызовов, runtime errors и latency используй готовые service dashboards
 Cloud Functions. В отдельный компактный dashboard добавь ключевые error counters,
@@ -511,16 +527,16 @@ multialert создаёт отдельный subalert по `resource_id`, поэ
 Контролируемые HTTP `400/403/405/413` не являются runtime failures и в этот
 график не попадают.
 
-Для сайта используй компактный dashboard Monium: `edge.requests`, page views,
-доли `browser_like` / `known_bot` / `synthetic` / `unknown` и карточку
-**Последний page view**. Sessions пока не считаются. Cache/status/bytes/latency
+Для сайта используй компактный dashboard Monium: `edge.requests`, page views за
+пять минут и разбивку `browser_like` / `known_bot` / `synthetic` / `unknown`.
+Sessions пока не считаются. Cache/status/bytes/latency
 оставь на встроенных `edge.*` графиках Monitoring. Маркетинговые конверсии и
 источники кампаний остаются в маркетинговых счётчиках.
 
-Плитка **Последний page view** использует `series_sum` для объединения рядов
-`traffic_class × host` и агрегацию `last`. Она показывает последнее значение
-пятиминутного bucket в выбранном диапазоне, а не timestamp raw-log записи. Это
-намеренная диагностическая аппроксимация без новой метрики, state и alert.
+График **Просмотры страниц за 5 минут** использует `series_sum` для объединения
+рядов taxonomy и показывает count пятиминутного bucket. График **Просмотры
+страниц по классам трафика** сохраняет разбивку по `traffic_class`. Ни один из
+них не является paging-alert.
 
 ## Cost estimate
 

--- a/docs/site-traffic-analytics.md
+++ b/docs/site-traffic-analytics.md
@@ -69,42 +69,40 @@ Object Storage и отдельного lifecycle. Повторный `page_view_
 - source: production logs с `meta.application="zvenfit-frontend"`,
   `meta.environment="production"`, `meta.service="zvenfit-site-traffic"`;
 - filter/event: `meta.event="site_page_view"`, `meta.traffic_class="*"`,
-  `host="*"`; existence-фильтры для полей группировки обязательны в
+  `host="*"`, `resource_id="*"`; existence-фильтры для полей группировки обязательны в
   Preview-конструкторе Monium;
 - aggregation: count, window 5 minutes;
-- grouping: `meta.traffic_class`, `host` (в Monium `host` — системное поле, не `meta.host`).
+- grouping: `meta.traffic_class`, `meta.application`, `meta.service`,
+  `resource_id`. `host` остаётся полем raw log и не становится metric label.
 
 На dashboard добавь:
 
-1. stacked bars page views по `traffic_class`;
-2. долю `known_bot` и `synthetic`;
-3. плитку **Последний page view** с запросом
-   `series_sum({..., name="zvenfit_site_page_views_by_class_5m"})` и агрегацией `last`;
-4. при ручном разборе — top `meta.page` непосредственно в трёхдневных логах,
+1. график **Просмотры страниц за 5 минут** с запросом
+   `series_sum({..., name="zvenfit_site_page_views_by_class_5m"})`;
+2. stacked bars page views по `traffic_class`, включая долю `known_bot` и
+   `synthetic`;
+3. при ручном разборе — top `meta.page` непосредственно в трёхдневных логах,
    не как metric label;
-5. рядом встроенные `edge.requests`, `edge.requests_status`,
+4. рядом встроенные `edge.requests`, `edge.requests_status`,
    `edge.requests_cache_status`, `edge.bytes_sent` и
    `edge.request_time_seconds` для CDN resource `bc8rubabuwzpqqp7rifz`.
-6. в общий диагностический график `functions_errors` добавь
+5. в общий диагностический график `functions_errors` добавь
    `resource_id="zvenfit-site-traffic"`, но не создавай для аналитики paging-alert.
 
 Старые виджеты **Трафик: запросы по классам** и
 **Трафик: технические сессии людей** относятся к удалённой stateful-схеме
 и должны быть удалены с dashboard.
 
-Freshness-card не является paging-alert: задержка или потеря технической
-аналитики не должна попадать в критичный lead alert.
-
-Пользовательский dashboard Monium не поддерживает raw-log widget. Поэтому плитка
-показывает последнее значение объединённого пятиминутного bucket, а не точный
-timestamp строки лога. Для точного времени последнего `site_page_view` используй
+Эти графики не являются paging-alert: задержка или потеря технической аналитики
+не должна попадать в критичный lead alert. Пользовательский dashboard Monium не
+поддерживает raw-log widget. Для точного времени последнего `site_page_view` используй
 Cloud Logging с тем же event selector. Добавлять ради этого отдельную timestamp-
 метрику или application state не нужно.
 
 ## Стоимость и ограничения
 
 При масштабе ZvenFit вызовы функции и объём трёхдневных логов должны помещаться
-в общие free tiers billing account. Log-derived metric с тремя ограниченными
+в общие free tiers billing account. Log-derived metric с четырьмя ограниченными
 labels стоит пренебрежимо мало. Проверяй фактическое потребление в billing:
 free tiers разделяются с другими ресурсами аккаунта.
 

--- a/knowledge-base/dashboards.md
+++ b/knowledge-base/dashboards.md
@@ -7,6 +7,7 @@ updated: 2026-08-16
 # Production monitoring dashboard
 
 - URL: https://monium.yandex.cloud/projects/folder__b1ge1e4iopttj79hfdfm/dashboards/zvenfit-production-monitoring
+- Native JSON snapshot: [`scripts/monitoring.dashboard.json`](../scripts/monitoring.dashboard.json).
 - Purpose: production lead pipeline, Telegram delivery, Fitbase schedule, Cloud Functions, traffic, and YDB health.
 - Reading order: alert statuses, Telegram queue and heartbeat, then application and Cloud Functions diagnostics.
 - The first row contains one-click `INFO за час` and `ERROR за час` links to
@@ -14,6 +15,17 @@ updated: 2026-08-16
   monitoring runbook.
 - Empty event graphs are normal while the corresponding alert is green.
 - Refresh interval: one minute.
+
+## Backup and restore
+
+- Export/import path: **Dashboard settings → JSON**.
+- Export with **Без diff**; restore by pasting the Git snapshot and reviewing
+  **Встроенный diff** before **Применить**.
+- The snapshot covers only the dashboard. Alerts, log metrics and notification
+  channels remain described by `scripts/monitoring.config.json` and are managed
+  separately.
+- After an intentional live change, export again and commit the server-normalized
+  JSON. Do not hand-maintain Monium-generated UUIDs.
 
 ## Taxonomy and naming
 

--- a/scripts/__tests__/monitoring-config.test.cjs
+++ b/scripts/__tests__/monitoring-config.test.cjs
@@ -7,6 +7,8 @@ const test = require('node:test');
 
 const ROOT = path.resolve(__dirname, '../..');
 const config = JSON.parse(fs.readFileSync(path.join(ROOT, 'scripts/monitoring.config.json'), 'utf8'));
+const dashboardExportText = fs.readFileSync(path.join(ROOT, 'scripts/monitoring.dashboard.json'), 'utf8');
+const dashboardExport = JSON.parse(dashboardExportText);
 const source = [
   'functions/lead-intake/src/handler.ts',
   'functions/lead-intake/src/notification/delivery.ts',
@@ -56,6 +58,95 @@ test('dashboard exposes the canonical one-hour INFO and ERROR log links', () => 
   }
 
   assert.notEqual(quickAccess.links[0].url, quickAccess.links[1].url);
+});
+
+test('native dashboard JSON is restorable and matches critical desired-state invariants', () => {
+  assert.deepEqual(config.dashboard.nativeJson, {
+    artifact: 'scripts/monitoring.dashboard.json',
+    scope: 'dashboard-only',
+    workflow: 'settings-json-export-import',
+  });
+  assert.equal(dashboardExport.title, 'ZvenFit · production');
+  assert.equal(dashboardExport.name, 'zvenfit-production-monitoring');
+  assert.equal(dashboardExport.widgets.length, 24);
+
+  const quickAccessWidget = dashboardExport.widgets.find(
+    widget => widget.widget === 'text' && widget.text?.text?.includes('Быстрый доступ к логам'),
+  );
+  assert.ok(quickAccessWidget, 'native dashboard export has no quick log access widget');
+  assert.deepEqual(quickAccessWidget.position, { x: '0', y: '0', w: '36', h: '2' });
+  for (const link of config.dashboard.quickLogAccess.links) {
+    assert.ok(
+      quickAccessWidget.text.text.includes(`[${link.label}](${link.url})`),
+      `${link.label} is missing from native dashboard export`,
+    );
+  }
+
+  const alertList = dashboardExport.widgets.find(widget => widget.widget === 'alertList');
+  assert.match(alertList.alertList.selectors, /application = "zvenfit-frontend"/);
+  assert.match(alertList.alertList.selectors, /environment = "production"/);
+
+  const chartTitles = dashboardExport.widgets
+    .filter(widget => widget.widget === 'multiSourceChart')
+    .map(widget => widget.multiSourceChart.title);
+  assert.equal(
+    chartTitles.some(title => title.startsWith('ZvenFit')),
+    false,
+  );
+  assert.ok(chartTitles.includes('Cloud Functions: длительность p95'));
+  assert.ok(chartTitles.includes('Поставка событий: heartbeat retry-worker'));
+
+  assert.doesNotMatch(dashboardExportText, /authorization|bearer\s|api[_-]?key|password|secret/i);
+  assert.doesNotMatch(dashboardExportText, /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/i);
+});
+
+test('dashboard log-aggregate filters are preserved by each metric grouping', () => {
+  const metricsById = new Map(config.logMetrics.map(metric => [metric.id, metric]));
+
+  for (const widget of dashboardExport.widgets.filter(item => item.widget === 'multiSourceChart')) {
+    for (const target of widget.multiSourceChart.targets || []) {
+      if (!target.query?.includes('service = "logging_aggregates"')) continue;
+
+      const metricNames = target.query.match(/name = "([^"]+)"/)?.[1].split('|') || [];
+      const filteredMetadata = [...target.query.matchAll(/(meta\.[a-z_]+) = /g)].map(match => match[1]);
+
+      for (const metricName of metricNames) {
+        const metric = metricsById.get(metricName);
+        assert.ok(metric, `${widget.multiSourceChart.title} references unknown log metric ${metricName}`);
+        for (const label of filteredMetadata) {
+          assert.ok(
+            metric.grouping?.includes(label),
+            `${metricName} filters by ${label}, but the log metric does not preserve it in grouping`,
+          );
+        }
+      }
+    }
+  }
+});
+
+test('log metrics preserve the live taxonomy required to isolate products and functions', () => {
+  const applicationGrouping = ['meta.application', 'meta.environment', 'meta.service', 'resource_id'];
+  const applicationMetricIds = [
+    'zvenfit_lead_storage_errors_1m',
+    'zvenfit_telegram_delivery_failed_1m',
+    'zvenfit_fitbase_errors_5m',
+    'zvenfit_ydb_retries_5m',
+    'zvenfit_ydb_slow_operations_5m',
+    'zvenfit_rate_limit_errors_5m',
+    'zvenfit_lead_rate_limited_5m',
+    'zvenfit_leads_persisted_5m',
+    'zvenfit_retry_worker_log_heartbeat_1m',
+  ];
+
+  for (const metricId of applicationMetricIds) {
+    const metric = config.logMetrics.find(item => item.id === metricId);
+    assert.deepEqual(metric.grouping, applicationGrouping, `${metricId} has stale taxonomy grouping`);
+  }
+
+  for (const metricId of ['zvenfit_schedule_runtime_errors_1m', 'zvenfit_schedule_client_cancellations_5m']) {
+    const metric = config.logMetrics.find(item => item.id === metricId);
+    assert.deepEqual(metric.grouping, ['resource_id']);
+  }
 });
 
 test('every monitored event exists in application code and documentation', () => {
@@ -135,7 +226,11 @@ test('anti-spam and accepted lead volume thresholds are explicit', () => {
   const rateAlert = config.alerts.find(alert => alert.id === 'zvenfit_rate-limited_leads');
   const volumeAlert = config.alerts.find(alert => alert.id === 'zvenfit_persisted_leads_volume');
 
-  assert.deepEqual(rateMetric.filters, { 'meta.reason': 'rate_limit' });
+  assert.deepEqual(rateMetric.filters, {
+    'meta.service': 'zvenfit-lead-intake',
+    'meta.reason': 'rate_limit',
+    resource_id: '*',
+  });
   assert.deepEqual(
     { warning: rateAlert.warning, alarm: rateAlert.alarm, window: rateAlert.window },
     { warning: 0, alarm: 5, window: '10m' },
@@ -388,7 +483,7 @@ test('retry worker health covers missing heartbeats, delivery backlog, and trigg
     id: 'zvenfit_retry_worker_log_heartbeat_1m',
     displayName: 'ZvenFit · Retry-worker: поставка событий',
     events: ['retry_worker_completed'],
-    filters: { resource_id: '*' },
+    filters: { 'meta.service': 'zvenfit-lead-intake', resource_id: '*' },
     aggregation: 'count',
     window: '1m',
     grouping: ['meta.application', 'meta.environment', 'meta.service', 'resource_id'],
@@ -433,7 +528,9 @@ test('transient Telegram retries remain log-only', () => {
   const monitoredEvents = config.logMetrics.flatMap(metric => metric.events || []);
 
   assert.equal(monitoredEvents.includes('telegram_delivery_retry_scheduled'), false);
+  assert.equal(monitoredEvents.includes('telegram_delivery_retry_error'), false);
   assert.match(monitoringDocs, /`telegram_delivery_retry_scheduled`\s+\| Telegram временно недоступен/);
+  assert.match(monitoringDocs, /`telegram_delivery_retry_error`\s+\| Retry-задача не смогла обработать заявку/);
 });
 
 test('production log source and retention are explicit', () => {
@@ -472,14 +569,13 @@ test('technical traffic analytics uses a stateless page-view log and built-in ed
     'unknown',
   ]);
   assert.deepEqual(config.trafficAnalytics.measures, ['edge_requests', 'page_views']);
-  assert.equal(config.trafficAnalytics.freshnessCard.title, 'Последний page view');
-  assert.equal(config.trafficAnalytics.freshnessCard.source, 'zvenfit_site_page_views_by_class_5m');
-  assert.match(config.trafficAnalytics.freshnessCard.query, /^series_sum\(/);
-  assert.match(config.trafficAnalytics.freshnessCard.query, /name="zvenfit_site_page_views_by_class_5m"/);
-  assert.equal(config.trafficAnalytics.freshnessCard.visualization, 'tile');
-  assert.equal(config.trafficAnalytics.freshnessCard.aggregation, 'last');
-  assert.equal(config.trafficAnalytics.freshnessCard.exactLogTimestamp, false);
-  assert.equal(config.trafficAnalytics.freshnessCard.pagingAlert, false);
+  assert.equal(config.trafficAnalytics.pageViewsChart.title, 'Просмотры страниц за 5 минут');
+  assert.equal(config.trafficAnalytics.pageViewsChart.source, 'zvenfit_site_page_views_by_class_5m');
+  assert.match(config.trafficAnalytics.pageViewsChart.query, /^series_sum\(/);
+  assert.match(config.trafficAnalytics.pageViewsChart.query, /name="zvenfit_site_page_views_by_class_5m"/);
+  assert.equal(config.trafficAnalytics.pageViewsChart.visualization, 'chart');
+  assert.equal(config.trafficAnalytics.pageViewsChart.bucket, '5m');
+  assert.equal(config.trafficAnalytics.pageViewsChart.pagingAlert, false);
   assert.deepEqual(metric, {
     id: 'zvenfit_site_page_views_by_class_5m',
     events: ['site_page_view'],
@@ -487,10 +583,11 @@ test('technical traffic analytics uses a stateless page-view log and built-in ed
       'meta.service': 'zvenfit-site-traffic',
       'meta.traffic_class': '*',
       host: '*',
+      resource_id: '*',
     },
     aggregation: 'count',
     window: '5m',
-    grouping: ['meta.traffic_class', 'host'],
+    grouping: ['meta.traffic_class', 'meta.application', 'meta.service', 'resource_id'],
     synthetic: false,
   });
   for (const metricName of [
@@ -520,7 +617,7 @@ test('traffic runtime errors page through the shared multialert and legacy state
   const runtimeErrors = config.dashboard.runtimeErrors;
   const criticalRuntimeAlert = config.alerts.find(alert => alert.id === 'zvenfit_function_runtime_errors');
 
-  assert.equal(runtimeErrors.title, 'Ошибки Cloud Functions');
+  assert.equal(runtimeErrors.title, 'Cloud Functions: ошибки');
   assert.match(runtimeErrors.metricSelector, /name="functions_errors"/);
   assert.match(runtimeErrors.metricSelector, /zvenfit-telegram-lead/);
   assert.match(runtimeErrors.metricSelector, /zvenfit-fitbase-schedule/);
@@ -531,8 +628,8 @@ test('traffic runtime errors page through the shared multialert and legacy state
   assert.deepEqual(config.dashboard.trafficWidgets, [
     'Cloud CDN: запросы',
     'Cloud CDN: HTTP-статусы',
-    'Трафик: просмотры страниц по классам',
-    'Последний page view',
+    'Просмотры страниц за 5 минут',
+    'Просмотры страниц по классам трафика',
   ]);
   assert.deepEqual(config.dashboard.removeTrafficWidgets, [
     'Трафик: запросы по классам',
@@ -561,13 +658,14 @@ test('every log selector is isolated by repository and environment', () => {
   }
 });
 
-test('manual provisioning and notification channel requirements are explicit', () => {
+test('native dashboard import and manual resource provisioning are explicit', () => {
   assert.deepEqual(config.provisioning, {
+    dashboard: 'native-json-import',
     logMetrics: 'manual-console',
     notificationChannels: 'manual-console',
     alerts: 'manual-console',
     reason:
-      'Log metrics, alert rules and notification channels remain console-managed; the repository stores the reviewed desired state and validates read-only snapshots',
+      'The dashboard uses Monium native JSON export/import; log metrics, alert rules and notification channels remain console-managed',
   });
   assert.deepEqual(config.notificationChannels, [
     {

--- a/scripts/__tests__/monitoring-drift.test.cjs
+++ b/scripts/__tests__/monitoring-drift.test.cjs
@@ -21,7 +21,7 @@ test('normalizes the desired monitoring resources into a stable read-only contra
   assert.equal(normalized.logMetrics.length, 12);
   assert.equal(normalized.alerts.length, 16);
   assert.equal(normalized.notificationChannels.length, 2);
-  assert.equal(normalized.dashboard.runtimeErrors.title, 'Ошибки Cloud Functions');
+  assert.equal(normalized.dashboard.runtimeErrors.title, 'Cloud Functions: ошибки');
   assert.deepEqual(diffMonitoringState(config, liveSnapshot()), []);
 });
 

--- a/scripts/monitoring.config.json
+++ b/scripts/monitoring.config.json
@@ -33,13 +33,12 @@
     ],
     "measures": ["edge_requests", "page_views"],
     "pageViewMetricId": "zvenfit_site_page_views_by_class_5m",
-    "freshnessCard": {
-      "title": "Последний page view",
+    "pageViewsChart": {
+      "title": "Просмотры страниц за 5 минут",
       "source": "zvenfit_site_page_views_by_class_5m",
       "query": "series_sum({project=\"folder__b1ge1e4iopttj79hfdfm\", cluster=\"default\", service=\"logging_aggregates\", name=\"zvenfit_site_page_views_by_class_5m\"})",
-      "visualization": "tile",
-      "aggregation": "last",
-      "exactLogTimestamp": false,
+      "visualization": "chart",
+      "bucket": "5m",
       "pagingAlert": false
     },
     "monitoringSelectors": {
@@ -58,6 +57,11 @@
     }
   },
   "dashboard": {
+    "nativeJson": {
+      "artifact": "scripts/monitoring.dashboard.json",
+      "scope": "dashboard-only",
+      "workflow": "settings-json-export-import"
+    },
     "quickLogAccess": {
       "title": "Быстрый доступ к логам",
       "position": "top",
@@ -81,7 +85,7 @@
       ]
     },
     "runtimeErrors": {
-      "title": "Ошибки Cloud Functions",
+      "title": "Cloud Functions: ошибки",
       "metricSelector": "{project=\"folder__b1ge1e4iopttj79hfdfm\", service=\"serverless-functions\", name=\"functions_errors\", resource_id=\"zvenfit-telegram-lead|zvenfit-fitbase-schedule|zvenfit-site-traffic\"}",
       "pagingAlert": true,
       "decomposeBy": ["resource_id"]
@@ -103,8 +107,8 @@
     "trafficWidgets": [
       "Cloud CDN: запросы",
       "Cloud CDN: HTTP-статусы",
-      "Трафик: просмотры страниц по классам",
-      "Последний page view"
+      "Просмотры страниц за 5 минут",
+      "Просмотры страниц по классам трафика"
     ],
     "removeTrafficWidgets": [
       "Трафик: запросы по классам",
@@ -112,10 +116,11 @@
     ]
   },
   "provisioning": {
+    "dashboard": "native-json-import",
     "logMetrics": "manual-console",
     "notificationChannels": "manual-console",
     "alerts": "manual-console",
-    "reason": "Log metrics, alert rules and notification channels remain console-managed; the repository stores the reviewed desired state and validates read-only snapshots"
+    "reason": "The dashboard uses Monium native JSON export/import; log metrics, alert rules and notification channels remain console-managed"
   },
   "notificationChannels": [
     {
@@ -140,58 +145,73 @@
   "logMetrics": [
     {
       "id": "zvenfit_lead_storage_errors_1m",
-      "events": ["lead_storage_error", "telegram_delivery_retry_error"],
+      "events": ["lead_storage_error"],
+      "filters": { "meta.service": "zvenfit-lead-intake", "resource_id": "*" },
       "aggregation": "count",
-      "window": "1m"
+      "window": "1m",
+      "grouping": ["meta.application", "meta.environment", "meta.service", "resource_id"]
     },
     {
       "id": "zvenfit_telegram_delivery_failed_1m",
       "events": ["telegram_delivery_failed_permanently"],
+      "filters": { "meta.service": "zvenfit-lead-intake", "resource_id": "*" },
       "aggregation": "count",
-      "window": "1m"
+      "window": "1m",
+      "grouping": ["meta.application", "meta.environment", "meta.service", "resource_id"]
     },
     {
       "id": "zvenfit_fitbase_errors_5m",
       "events": ["fitbase_schedule_error", "fitbase_schedule_misconfigured"],
+      "filters": { "meta.service": "zvenfit-fitbase-schedule", "resource_id": "*" },
       "aggregation": "count",
-      "window": "5m"
+      "window": "5m",
+      "grouping": ["meta.application", "meta.environment", "meta.service", "resource_id"]
     },
     {
       "id": "zvenfit_ydb_retries_5m",
       "events": ["ydb_retry"],
+      "filters": { "meta.service": "zvenfit-lead-intake", "resource_id": "*" },
       "aggregation": "count",
-      "window": "5m"
+      "window": "5m",
+      "grouping": ["meta.application", "meta.environment", "meta.service", "resource_id"]
     },
     {
       "id": "zvenfit_ydb_slow_operations_5m",
       "events": ["ydb_slow_operation"],
+      "filters": { "meta.service": "zvenfit-lead-intake", "resource_id": "*" },
       "aggregation": "count",
-      "window": "5m"
+      "window": "5m",
+      "grouping": ["meta.application", "meta.environment", "meta.service", "resource_id"]
     },
     {
       "id": "zvenfit_rate_limit_errors_5m",
       "events": ["lead_rate_limit_error"],
+      "filters": { "meta.service": "zvenfit-lead-intake", "resource_id": "*" },
       "aggregation": "count",
-      "window": "5m"
+      "window": "5m",
+      "grouping": ["meta.application", "meta.environment", "meta.service", "resource_id"]
     },
     {
       "id": "zvenfit_lead_rate_limited_5m",
       "events": ["lead_submission_blocked"],
-      "filters": { "meta.reason": "rate_limit" },
+      "filters": { "meta.service": "zvenfit-lead-intake", "meta.reason": "rate_limit", "resource_id": "*" },
       "aggregation": "count",
-      "window": "5m"
+      "window": "5m",
+      "grouping": ["meta.application", "meta.environment", "meta.service", "resource_id"]
     },
     {
       "id": "zvenfit_leads_persisted_5m",
       "events": ["lead_persisted"],
+      "filters": { "meta.service": "zvenfit-lead-intake", "resource_id": "*" },
       "aggregation": "count",
-      "window": "5m"
+      "window": "5m",
+      "grouping": ["meta.application", "meta.environment", "meta.service", "resource_id"]
     },
     {
       "id": "zvenfit_retry_worker_log_heartbeat_1m",
       "displayName": "ZvenFit · Retry-worker: поставка событий",
       "events": ["retry_worker_completed"],
-      "filters": { "resource_id": "*" },
+      "filters": { "meta.service": "zvenfit-lead-intake", "resource_id": "*" },
       "aggregation": "count",
       "window": "1m",
       "grouping": ["meta.application", "meta.environment", "meta.service", "resource_id"],
@@ -203,6 +223,7 @@
       "selector": "{project=\"folder__b1ge1e4iopttj79hfdfm\", cluster=\"default\", service=\"default\", resource_type=\"serverless.function\", resource_id=\"d4e80noc1hjn2g8u0beq\", level=\"ERROR\", message!=*\"Code: 499\"}",
       "aggregation": "count",
       "window": "1m",
+      "grouping": ["resource_id"],
       "synthetic": false
     },
     {
@@ -211,6 +232,7 @@
       "selector": "{project=\"folder__b1ge1e4iopttj79hfdfm\", cluster=\"default\", service=\"default\", resource_type=\"serverless.function\", resource_id=\"d4e80noc1hjn2g8u0beq\", level=\"ERROR\", message=*\"Code: 499\"}",
       "aggregation": "count",
       "window": "5m",
+      "grouping": ["resource_id"],
       "synthetic": false
     },
     {
@@ -219,11 +241,12 @@
       "filters": {
         "meta.service": "zvenfit-site-traffic",
         "meta.traffic_class": "*",
-        "host": "*"
+        "host": "*",
+        "resource_id": "*"
       },
       "aggregation": "count",
       "window": "5m",
-      "grouping": ["meta.traffic_class", "host"],
+      "grouping": ["meta.traffic_class", "meta.application", "meta.service", "resource_id"],
       "synthetic": false
     }
   ],

--- a/scripts/monitoring.dashboard.json
+++ b/scripts/monitoring.dashboard.json
@@ -1,0 +1,1816 @@
+{
+  "title": "ZvenFit · production",
+  "name": "zvenfit-production-monitoring",
+  "description": "",
+  "parametrization": null,
+  "eventSources": {
+    "infra": []
+  },
+  "widgets": [
+    {
+      "links": [],
+      "position": {
+        "x": "0",
+        "y": "0",
+        "w": "36",
+        "h": "2"
+      },
+      "text": {
+        "text": "**Быстрый доступ к логам:** [INFO за час](https://monium.yandex.cloud/projects/folder__b1ge1e4iopttj79hfdfm/logs?tab=logs&queries=NobwRAdghgtgpmAXGAgmANGAblANgVwWRAAcAnAewCs4BjAFwAIBeRgHTADMLcATOMgH1BAIwCMAczhi4AFgCWFEvXpUA7AE4AFp16cYHdIwDOArPNpwW7MP05R8ueoca44WOLmscAkgDkAMQB5F3h6KAA6KBISXAsoekUIbzAALw8ITnl6AFpOSgh6OAheULhwiOLzAvhClPIKXnwGJI4AXwwwLXlefggke1xTTF55YygRN14BvGGwIoAPegBZRqJB0zaAXSA&from=now-1h&to=now&columns=level%2Ctime%2Cmessage%2Chost&groupByField=level&chartType=column&linesMode=single&refresh=off) · [ERROR за час](https://monium.yandex.cloud/projects/folder__b1ge1e4iopttj79hfdfm/logs?tab=logs&queries=NobwRAdghgtgpmAXGAgmANGAblANgVwWRAAcAnAewCs4BjAFwAIBeRgHTADMLcATOMgH1BAIwCMAczhi4AFgCWFEvXpUA7AE4AFp16cYHdIwDOArPNpwW7MP05R8ueoca44WOLmscAogCU-AHk-F3h6KAA6KBISXAsoekUIbzAALw8ITnl6AFpOSgh6OAheULhwiOLzAvhClPIKXnwGJI4AXwwwLXlefggke1xTTF55YygRN14BvGGwIoAPegBZRqJB0zaAXSA&from=now-1h&to=now&columns=level%2Ctime%2Cmessage%2Chost&groupByField=level&chartType=column&linesMode=single&refresh=off)"
+      },
+      "widget": "text"
+    },
+    {
+      "links": [],
+      "position": {
+        "x": "0",
+        "y": "2",
+        "w": "36",
+        "h": "5"
+      },
+      "text": {
+        "text": "Как читать дашборд\n\n1. Статусы: красный — реагировать; жёлтый — проверить; зелёный — норма.\n2. Доставка: очередь заявок → возраст старейшей → heartbeat retry-worker.\n3. Диагностика: ошибки, ограничения и ресурсы каждой Cloud Function различаются по resource_id.\n\nПустой событийный график при зелёном статусе означает, что ошибок не было. Обновление — раз в минуту."
+      },
+      "widget": "text"
+    },
+    {
+      "links": [],
+      "position": {
+        "x": "0",
+        "y": "7",
+        "w": "36",
+        "h": "2"
+      },
+      "title": {
+        "text": "Поток заявок и доставка",
+        "size": "TITLE_SIZE_L"
+      },
+      "widget": "title"
+    },
+    {
+      "links": [],
+      "position": {
+        "x": "0",
+        "y": "9",
+        "w": "36",
+        "h": "5"
+      },
+      "alertList": {
+        "annotationNames": [],
+        "groupByLabels": [],
+        "selectors": "{application = \"zvenfit-frontend\", environment = \"production\"}",
+        "showAllAnnotations": false,
+        "title": "Состояние production",
+        "pageSize": 100,
+        "groupMultiAlert": true,
+        "allLabelsGrouping": false,
+        "projectId": "folder__b1ge1e4iopttj79hfdfm",
+        "widgetScope": "projectId",
+        "orderByStatus": "ASC",
+        "orderBy": "orderByStatus",
+        "manualLayout": false,
+        "_manualLayout": "manualLayout"
+      },
+      "widget": "alertList"
+    },
+    {
+      "links": [],
+      "position": {
+        "x": "0",
+        "y": "14",
+        "w": "18",
+        "h": "8"
+      },
+      "multiSourceChart": {
+        "targets": [
+          {
+            "dataSourceId": "37bb817c-c972-46ed-8087-d7d2517bac05",
+            "query": "{project = \"folder__b1ge1e4iopttj79hfdfm\", service = \"serverless-functions\", name = \"functions_errors\", resource_id = \"zvenfit-telegram-lead|zvenfit-fitbase-schedule|zvenfit-site-traffic\"}",
+            "textMode": true,
+            "hidden": false,
+            "name": "A",
+            "type": "monitoring"
+          }
+        ],
+        "dataSources": [
+          {
+            "id": "37bb817c-c972-46ed-8087-d7d2517bac05",
+            "downsampling": {
+              "gridAggregation": "GRID_AGGREGATION_UNSPECIFIED",
+              "gapFilling": "GAP_FILLING_UNSPECIFIED"
+            },
+            "type": "monitoring"
+          }
+        ],
+        "seriesOverrides": [],
+        "overlays": [],
+        "id": "Oo3SMsveeKkr0DBMFATBF",
+        "visualizationSettings": {
+          "type": "VISUALIZATION_TYPE_UNSPECIFIED",
+          "normalize": false,
+          "interpolate": "INTERPOLATE_UNSPECIFIED",
+          "aggregation": "SERIES_AGGREGATION_UNSPECIFIED",
+          "colorSchemeSettings": {
+            "automatic": {},
+            "scheme": "automatic"
+          },
+          "heatmapSettings": null,
+          "yaxisSettings": {
+            "left": {
+              "type": "YAXIS_TYPE_LINEAR",
+              "title": "Ошибок",
+              "min": "",
+              "max": "",
+              "unitFormat": "UNIT_FORMAT_UNSPECIFIED",
+              "precision": null
+            },
+            "right": {
+              "type": "YAXIS_TYPE_LINEAR",
+              "title": "",
+              "min": "",
+              "max": "",
+              "unitFormat": "UNIT_FORMAT_UNSPECIFIED",
+              "precision": null
+            }
+          },
+          "title": "",
+          "showLabels": true,
+          "tilesSettings": null,
+          "hidePartialData": false
+        },
+        "nameHidingSettings": null,
+        "description": "",
+        "title": "Cloud Functions: ошибки",
+        "displayLegend": true,
+        "freeze": "FREEZE_DURATION_UNSPECIFIED",
+        "repeat": null,
+        "thresholds": {
+          "items": [
+            {
+              "color": "#92db00",
+              "id": "c19f1e44-d054-463a-a1c1-e33102a6c5de"
+            }
+          ],
+          "showMode": "CONSTANT_LINE"
+        },
+        "eventSources": null,
+        "legendSettings": {
+          "sortRules": [],
+          "position": "POSITION_BOTTOM",
+          "truncate": "TRUNCATE_END",
+          "size": null,
+          "list": {
+            "columnsCount": 0
+          },
+          "view": "list"
+        }
+      },
+      "widget": "multiSourceChart"
+    },
+    {
+      "links": [],
+      "position": {
+        "x": "18",
+        "y": "14",
+        "w": "18",
+        "h": "8"
+      },
+      "multiSourceChart": {
+        "targets": [
+          {
+            "dataSourceId": "37bb817c-c972-46ed-8087-d7d2517bac05",
+            "query": "{project = \"folder__b1ge1e4iopttj79hfdfm\", cluster = \"default\", service = \"logging_aggregates\", name = \"zvenfit_ydb_retries_5m|zvenfit_ydb_slow_operations_5m\", meta.application = \"zvenfit-frontend\", meta.environment = \"production\", meta.service = \"zvenfit-lead-intake\"}",
+            "textMode": true,
+            "hidden": false,
+            "name": "A",
+            "type": "monitoring"
+          }
+        ],
+        "dataSources": [
+          {
+            "id": "37bb817c-c972-46ed-8087-d7d2517bac05",
+            "downsampling": {
+              "gridAggregation": "GRID_AGGREGATION_UNSPECIFIED",
+              "gapFilling": "GAP_FILLING_UNSPECIFIED"
+            },
+            "type": "monitoring"
+          }
+        ],
+        "seriesOverrides": [],
+        "overlays": [],
+        "id": "1tXoGDglimXdBSIO5JKuL",
+        "visualizationSettings": {
+          "type": "VISUALIZATION_TYPE_UNSPECIFIED",
+          "normalize": false,
+          "interpolate": "INTERPOLATE_UNSPECIFIED",
+          "aggregation": "SERIES_AGGREGATION_UNSPECIFIED",
+          "colorSchemeSettings": {
+            "automatic": {},
+            "scheme": "automatic"
+          },
+          "heatmapSettings": null,
+          "yaxisSettings": {
+            "left": {
+              "type": "YAXIS_TYPE_LINEAR",
+              "title": "Событий / 5 мин",
+              "min": "",
+              "max": "",
+              "unitFormat": "UNIT_FORMAT_UNSPECIFIED",
+              "precision": null
+            },
+            "right": {
+              "type": "YAXIS_TYPE_LINEAR",
+              "title": "",
+              "min": "",
+              "max": "",
+              "unitFormat": "UNIT_FORMAT_UNSPECIFIED",
+              "precision": null
+            }
+          },
+          "title": "",
+          "showLabels": false,
+          "tilesSettings": null,
+          "hidePartialData": false
+        },
+        "nameHidingSettings": null,
+        "description": "",
+        "title": "YDB: повторы и медленные операции",
+        "displayLegend": false,
+        "freeze": "FREEZE_DURATION_UNSPECIFIED",
+        "repeat": null,
+        "thresholds": {
+          "items": [
+            {
+              "color": "#92db00",
+              "id": "b605e200-719c-4964-9fe0-9e3d4920a097"
+            }
+          ],
+          "showMode": "CONSTANT_LINE"
+        },
+        "eventSources": null,
+        "legendSettings": {
+          "sortRules": [],
+          "position": "POSITION_BOTTOM",
+          "truncate": "TRUNCATE_END",
+          "size": null,
+          "list": {
+            "columnsCount": 0
+          },
+          "view": "list"
+        }
+      },
+      "widget": "multiSourceChart"
+    },
+    {
+      "links": [],
+      "position": {
+        "x": "0",
+        "y": "22",
+        "w": "18",
+        "h": "8"
+      },
+      "multiSourceChart": {
+        "targets": [
+          {
+            "dataSourceId": "37bb817c-c972-46ed-8087-d7d2517bac05",
+            "query": "{project = \"folder__b1ge1e4iopttj79hfdfm\", cluster = \"default\", service = \"logging_aggregates\", name = \"zvenfit_telegram_delivery_failed_1m|zvenfit_lead_storage_errors_1m\", meta.application = \"zvenfit-frontend\", meta.environment = \"production\", meta.service = \"zvenfit-lead-intake\"}",
+            "textMode": true,
+            "hidden": false,
+            "name": "A",
+            "type": "monitoring"
+          }
+        ],
+        "dataSources": [
+          {
+            "id": "37bb817c-c972-46ed-8087-d7d2517bac05",
+            "downsampling": {
+              "gridAggregation": "GRID_AGGREGATION_UNSPECIFIED",
+              "gapFilling": "GAP_FILLING_UNSPECIFIED"
+            },
+            "type": "monitoring"
+          }
+        ],
+        "seriesOverrides": [],
+        "overlays": [],
+        "id": "A5A87xN1JSqcz999mk5Qx",
+        "visualizationSettings": {
+          "type": "VISUALIZATION_TYPE_UNSPECIFIED",
+          "normalize": false,
+          "interpolate": "INTERPOLATE_UNSPECIFIED",
+          "aggregation": "SERIES_AGGREGATION_UNSPECIFIED",
+          "colorSchemeSettings": {
+            "automatic": {},
+            "scheme": "automatic"
+          },
+          "heatmapSettings": null,
+          "yaxisSettings": {
+            "left": {
+              "type": "YAXIS_TYPE_LINEAR",
+              "title": "Ошибок",
+              "min": "",
+              "max": "",
+              "unitFormat": "UNIT_FORMAT_UNSPECIFIED",
+              "precision": null
+            },
+            "right": {
+              "type": "YAXIS_TYPE_LINEAR",
+              "title": "",
+              "min": "",
+              "max": "",
+              "unitFormat": "UNIT_FORMAT_UNSPECIFIED",
+              "precision": null
+            }
+          },
+          "title": "",
+          "showLabels": false,
+          "tilesSettings": null,
+          "hidePartialData": false
+        },
+        "nameHidingSettings": null,
+        "description": "",
+        "title": "Заявки и Telegram: ошибки",
+        "displayLegend": false,
+        "freeze": "FREEZE_DURATION_UNSPECIFIED",
+        "repeat": null,
+        "thresholds": {
+          "items": [
+            {
+              "color": "#92db00",
+              "id": "0ddb4a0a-ccd1-4c9f-84a7-23a2fda52227"
+            }
+          ],
+          "showMode": "CONSTANT_LINE"
+        },
+        "eventSources": null,
+        "legendSettings": {
+          "sortRules": [],
+          "position": "POSITION_BOTTOM",
+          "truncate": "TRUNCATE_END",
+          "size": null,
+          "list": {
+            "columnsCount": 0
+          },
+          "view": "list"
+        }
+      },
+      "widget": "multiSourceChart"
+    },
+    {
+      "links": [],
+      "position": {
+        "x": "18",
+        "y": "22",
+        "w": "18",
+        "h": "8"
+      },
+      "multiSourceChart": {
+        "targets": [
+          {
+            "dataSourceId": "37bb817c-c972-46ed-8087-d7d2517bac05",
+            "query": "{project = \"folder__b1ge1e4iopttj79hfdfm\", cluster = \"default\", service = \"logging_aggregates\", name = \"zvenfit_leads_persisted_5m\", meta.application = \"zvenfit-frontend\", meta.environment = \"production\", meta.service = \"zvenfit-lead-intake\"}",
+            "textMode": true,
+            "hidden": false,
+            "name": "A",
+            "type": "monitoring"
+          }
+        ],
+        "dataSources": [
+          {
+            "id": "37bb817c-c972-46ed-8087-d7d2517bac05",
+            "downsampling": {
+              "gridAggregation": "GRID_AGGREGATION_UNSPECIFIED",
+              "gapFilling": "GAP_FILLING_UNSPECIFIED"
+            },
+            "type": "monitoring"
+          }
+        ],
+        "seriesOverrides": [],
+        "overlays": [],
+        "id": "6121b627-b009-4bfd-b233-12e0f4dda6e3",
+        "visualizationSettings": {
+          "type": "VISUALIZATION_TYPE_UNSPECIFIED",
+          "normalize": false,
+          "interpolate": "INTERPOLATE_UNSPECIFIED",
+          "aggregation": "SERIES_AGGREGATION_UNSPECIFIED",
+          "colorSchemeSettings": {
+            "automatic": {},
+            "scheme": "automatic"
+          },
+          "heatmapSettings": null,
+          "yaxisSettings": {
+            "left": {
+              "type": "YAXIS_TYPE_LINEAR",
+              "title": "Заявок / 5 мин",
+              "min": "",
+              "max": "",
+              "unitFormat": "UNIT_FORMAT_UNSPECIFIED",
+              "precision": null
+            },
+            "right": {
+              "type": "YAXIS_TYPE_LINEAR",
+              "title": "",
+              "min": "",
+              "max": "",
+              "unitFormat": "UNIT_FORMAT_UNSPECIFIED",
+              "precision": null
+            }
+          },
+          "title": "",
+          "showLabels": false,
+          "tilesSettings": null,
+          "hidePartialData": false
+        },
+        "nameHidingSettings": null,
+        "description": "",
+        "title": "Сохранённые заявки за 5 минут",
+        "displayLegend": false,
+        "freeze": "FREEZE_DURATION_UNSPECIFIED",
+        "repeat": null,
+        "thresholds": {
+          "items": [
+            {
+              "color": "#92db00",
+              "id": "48043cf9-f5aa-4795-b0d3-2496981215cc"
+            }
+          ],
+          "showMode": "CONSTANT_LINE"
+        },
+        "eventSources": null,
+        "legendSettings": {
+          "sortRules": [],
+          "position": "POSITION_BOTTOM",
+          "truncate": "TRUNCATE_END",
+          "size": null,
+          "list": {
+            "columnsCount": 0
+          },
+          "view": "list"
+        }
+      },
+      "widget": "multiSourceChart"
+    },
+    {
+      "links": [],
+      "position": {
+        "x": "0",
+        "y": "30",
+        "w": "18",
+        "h": "8"
+      },
+      "multiSourceChart": {
+        "targets": [
+          {
+            "dataSourceId": "7921d8fb-90cf-4c3f-9be6-6eed90bc8503",
+            "query": "{project=\"folder__b1ge1e4iopttj79hfdfm\", cluster=\"default\", service=\"zvenfit-frontend\", name=\"zvenfit_telegram_oldest_pending_age_seconds\"}",
+            "textMode": true,
+            "hidden": false,
+            "name": "A",
+            "type": "monitoring"
+          }
+        ],
+        "dataSources": [
+          {
+            "id": "7921d8fb-90cf-4c3f-9be6-6eed90bc8503",
+            "downsampling": {
+              "gridAggregation": "GRID_AGGREGATION_UNSPECIFIED",
+              "gapFilling": "GAP_FILLING_UNSPECIFIED"
+            },
+            "type": "monitoring"
+          }
+        ],
+        "seriesOverrides": [],
+        "overlays": [],
+        "id": "d2a9d728-3afc-4e26-8557-9b73859988d2",
+        "visualizationSettings": {
+          "type": "VISUALIZATION_TYPE_UNSPECIFIED",
+          "normalize": false,
+          "interpolate": "INTERPOLATE_UNSPECIFIED",
+          "aggregation": "SERIES_AGGREGATION_UNSPECIFIED",
+          "colorSchemeSettings": {
+            "automatic": {},
+            "scheme": "automatic"
+          },
+          "heatmapSettings": null,
+          "yaxisSettings": {
+            "left": {
+              "type": "YAXIS_TYPE_LINEAR",
+              "title": "",
+              "min": "",
+              "max": "",
+              "unitFormat": "UNIT_FORMAT_UNSPECIFIED",
+              "precision": null
+            },
+            "right": {
+              "type": "YAXIS_TYPE_LINEAR",
+              "title": "",
+              "min": "",
+              "max": "",
+              "unitFormat": "UNIT_FORMAT_UNSPECIFIED",
+              "precision": null
+            }
+          },
+          "title": "",
+          "showLabels": false,
+          "tilesSettings": null,
+          "hidePartialData": false
+        },
+        "nameHidingSettings": null,
+        "description": "",
+        "title": "Telegram: возраст старейшей заявки, сек.",
+        "displayLegend": false,
+        "freeze": "FREEZE_DURATION_UNSPECIFIED",
+        "repeat": null,
+        "thresholds": {
+          "items": [
+            {
+              "color": "#92db00",
+              "id": "21b5dee0-a37c-4171-87b1-2f9b3763f3a7"
+            }
+          ],
+          "showMode": "CONSTANT_LINE"
+        },
+        "eventSources": null,
+        "legendSettings": {
+          "sortRules": [],
+          "position": "POSITION_BOTTOM",
+          "truncate": "TRUNCATE_END",
+          "size": null,
+          "list": {
+            "columnsCount": 0
+          },
+          "view": "list"
+        }
+      },
+      "widget": "multiSourceChart"
+    },
+    {
+      "links": [],
+      "position": {
+        "x": "18",
+        "y": "30",
+        "w": "18",
+        "h": "8"
+      },
+      "multiSourceChart": {
+        "targets": [
+          {
+            "dataSourceId": "11af2c1e-d95e-46c1-9baf-5c2eb228d3a8",
+            "query": "{project=\"folder__b1ge1e4iopttj79hfdfm\", cluster=\"default\", service=\"zvenfit-frontend\", name=\"zvenfit_telegram_pending_leads\"}",
+            "textMode": true,
+            "hidden": false,
+            "name": "A",
+            "type": "monitoring"
+          }
+        ],
+        "dataSources": [
+          {
+            "id": "11af2c1e-d95e-46c1-9baf-5c2eb228d3a8",
+            "downsampling": {
+              "gridAggregation": "GRID_AGGREGATION_UNSPECIFIED",
+              "gapFilling": "GAP_FILLING_UNSPECIFIED"
+            },
+            "type": "monitoring"
+          }
+        ],
+        "seriesOverrides": [],
+        "overlays": [],
+        "id": "050bd969-d926-462b-8ecd-fcfcf3349899",
+        "visualizationSettings": {
+          "type": "VISUALIZATION_TYPE_UNSPECIFIED",
+          "normalize": false,
+          "interpolate": "INTERPOLATE_UNSPECIFIED",
+          "aggregation": "SERIES_AGGREGATION_UNSPECIFIED",
+          "colorSchemeSettings": {
+            "automatic": {},
+            "scheme": "automatic"
+          },
+          "heatmapSettings": null,
+          "yaxisSettings": {
+            "left": {
+              "type": "YAXIS_TYPE_LINEAR",
+              "title": "",
+              "min": "",
+              "max": "",
+              "unitFormat": "UNIT_FORMAT_UNSPECIFIED",
+              "precision": null
+            },
+            "right": {
+              "type": "YAXIS_TYPE_LINEAR",
+              "title": "",
+              "min": "",
+              "max": "",
+              "unitFormat": "UNIT_FORMAT_UNSPECIFIED",
+              "precision": null
+            }
+          },
+          "title": "",
+          "showLabels": false,
+          "tilesSettings": null,
+          "hidePartialData": false
+        },
+        "nameHidingSettings": null,
+        "description": "",
+        "title": "Telegram: очередь доставки",
+        "displayLegend": false,
+        "freeze": "FREEZE_DURATION_UNSPECIFIED",
+        "repeat": null,
+        "thresholds": {
+          "items": [
+            {
+              "color": "#92db00",
+              "id": "ffbbe16a-91a3-4ff3-8183-9675b0725640"
+            }
+          ],
+          "showMode": "CONSTANT_LINE"
+        },
+        "eventSources": null,
+        "legendSettings": {
+          "sortRules": [],
+          "position": "POSITION_BOTTOM",
+          "truncate": "TRUNCATE_END",
+          "size": null,
+          "list": {
+            "columnsCount": 0
+          },
+          "view": "list"
+        }
+      },
+      "widget": "multiSourceChart"
+    },
+    {
+      "links": [],
+      "position": {
+        "x": "0",
+        "y": "38",
+        "w": "18",
+        "h": "8"
+      },
+      "multiSourceChart": {
+        "targets": [
+          {
+            "dataSourceId": "e80d6c98-db14-4012-b801-76702c53482d",
+            "query": "{project=\"folder__b1ge1e4iopttj79hfdfm\", cluster=\"default\", service=\"zvenfit-frontend\", name=\"zvenfit_retry_worker_heartbeat\"}",
+            "textMode": true,
+            "hidden": false,
+            "name": "A",
+            "type": "monitoring"
+          }
+        ],
+        "dataSources": [
+          {
+            "id": "e80d6c98-db14-4012-b801-76702c53482d",
+            "downsampling": {
+              "gridAggregation": "GRID_AGGREGATION_UNSPECIFIED",
+              "gapFilling": "GAP_FILLING_UNSPECIFIED"
+            },
+            "type": "monitoring"
+          }
+        ],
+        "seriesOverrides": [],
+        "overlays": [],
+        "id": "6473dbc7-80bc-4d00-9b73-69afa48acf3b",
+        "visualizationSettings": {
+          "type": "VISUALIZATION_TYPE_UNSPECIFIED",
+          "normalize": false,
+          "interpolate": "INTERPOLATE_UNSPECIFIED",
+          "aggregation": "SERIES_AGGREGATION_UNSPECIFIED",
+          "colorSchemeSettings": {
+            "automatic": {},
+            "scheme": "automatic"
+          },
+          "heatmapSettings": null,
+          "yaxisSettings": {
+            "left": {
+              "type": "YAXIS_TYPE_LINEAR",
+              "title": "",
+              "min": "",
+              "max": "",
+              "unitFormat": "UNIT_FORMAT_UNSPECIFIED",
+              "precision": null
+            },
+            "right": {
+              "type": "YAXIS_TYPE_LINEAR",
+              "title": "",
+              "min": "",
+              "max": "",
+              "unitFormat": "UNIT_FORMAT_UNSPECIFIED",
+              "precision": null
+            }
+          },
+          "title": "",
+          "showLabels": false,
+          "tilesSettings": null,
+          "hidePartialData": false
+        },
+        "nameHidingSettings": null,
+        "description": "",
+        "title": "Retry-worker: активность",
+        "displayLegend": false,
+        "freeze": "FREEZE_DURATION_UNSPECIFIED",
+        "repeat": null,
+        "thresholds": {
+          "items": [
+            {
+              "color": "#92db00",
+              "id": "9b7d6bfe-e730-4570-bdec-291a3f64d850"
+            }
+          ],
+          "showMode": "CONSTANT_LINE"
+        },
+        "eventSources": null,
+        "legendSettings": {
+          "sortRules": [],
+          "position": "POSITION_BOTTOM",
+          "truncate": "TRUNCATE_END",
+          "size": null,
+          "list": {
+            "columnsCount": 0
+          },
+          "view": "list"
+        }
+      },
+      "widget": "multiSourceChart"
+    },
+    {
+      "links": [],
+      "position": {
+        "x": "18",
+        "y": "38",
+        "w": "18",
+        "h": "8"
+      },
+      "multiSourceChart": {
+        "targets": [
+          {
+            "dataSourceId": "2ea57e72-f82e-4475-bcc1-7bc7d03390ef",
+            "query": "{project = \"folder__b1ge1e4iopttj79hfdfm\", cluster = \"default\", service = \"logging_aggregates\", name = \"zvenfit_rate_limit_errors_5m\", meta.application = \"zvenfit-frontend\", meta.environment = \"production\", meta.service = \"zvenfit-lead-intake\"}",
+            "textMode": true,
+            "hidden": false,
+            "name": "A",
+            "type": "monitoring"
+          },
+          {
+            "dataSourceId": "2ea57e72-f82e-4475-bcc1-7bc7d03390ef",
+            "query": "{project=\"folder__b1ge1e4iopttj79hfdfm\", service=\"serverless-functions\", name=\"serverless.triggers.access_error_per_second|serverless.triggers.error_per_second\", trigger=\"a1smkp9ng1f4g9vqgm7u\", type=\"request\"}",
+            "textMode": true,
+            "hidden": false,
+            "name": "B",
+            "type": "monitoring"
+          }
+        ],
+        "dataSources": [
+          {
+            "id": "2ea57e72-f82e-4475-bcc1-7bc7d03390ef",
+            "downsampling": {
+              "gridAggregation": "GRID_AGGREGATION_UNSPECIFIED",
+              "gapFilling": "GAP_FILLING_UNSPECIFIED"
+            },
+            "type": "monitoring"
+          }
+        ],
+        "seriesOverrides": [],
+        "overlays": [],
+        "id": "6fd34538-b51b-47c3-b3ad-cdf39c3b9c88",
+        "visualizationSettings": {
+          "type": "VISUALIZATION_TYPE_UNSPECIFIED",
+          "normalize": false,
+          "interpolate": "INTERPOLATE_UNSPECIFIED",
+          "aggregation": "SERIES_AGGREGATION_UNSPECIFIED",
+          "colorSchemeSettings": {
+            "automatic": {},
+            "scheme": "automatic"
+          },
+          "heatmapSettings": null,
+          "yaxisSettings": {
+            "left": {
+              "type": "YAXIS_TYPE_LINEAR",
+              "title": "",
+              "min": "",
+              "max": "",
+              "unitFormat": "UNIT_FORMAT_UNSPECIFIED",
+              "precision": null
+            },
+            "right": {
+              "type": "YAXIS_TYPE_LINEAR",
+              "title": "",
+              "min": "",
+              "max": "",
+              "unitFormat": "UNIT_FORMAT_UNSPECIFIED",
+              "precision": null
+            }
+          },
+          "title": "",
+          "showLabels": false,
+          "tilesSettings": null,
+          "hidePartialData": false
+        },
+        "nameHidingSettings": null,
+        "description": "",
+        "title": "Retry-trigger и rate limiter: ошибки",
+        "displayLegend": false,
+        "freeze": "FREEZE_DURATION_UNSPECIFIED",
+        "repeat": null,
+        "thresholds": {
+          "items": [
+            {
+              "color": "#92db00",
+              "id": "ff80611f-358e-45a3-8f23-d51c1c56206d"
+            }
+          ],
+          "showMode": "CONSTANT_LINE"
+        },
+        "eventSources": null,
+        "legendSettings": {
+          "sortRules": [],
+          "position": "POSITION_BOTTOM",
+          "truncate": "TRUNCATE_END",
+          "size": null,
+          "list": {
+            "columnsCount": 0
+          },
+          "view": "list"
+        }
+      },
+      "widget": "multiSourceChart"
+    },
+    {
+      "links": [],
+      "position": {
+        "x": "0",
+        "y": "46",
+        "w": "36",
+        "h": "2"
+      },
+      "title": {
+        "text": "Cloud Functions: лимиты и ресурсы",
+        "size": "TITLE_SIZE_L"
+      },
+      "widget": "title"
+    },
+    {
+      "links": [],
+      "position": {
+        "x": "0",
+        "y": "48",
+        "w": "18",
+        "h": "8"
+      },
+      "multiSourceChart": {
+        "targets": [
+          {
+            "dataSourceId": "37bb817c-c972-46ed-8087-d7d2517bac05",
+            "query": "{project = \"folder__b1ge1e4iopttj79hfdfm\", service = \"serverless-functions\", name = \"functions_throttles\", resource_id = \"zvenfit-telegram-lead|zvenfit-fitbase-schedule|zvenfit-site-traffic\"}",
+            "textMode": true,
+            "hidden": false,
+            "name": "A",
+            "type": "monitoring"
+          }
+        ],
+        "dataSources": [
+          {
+            "id": "37bb817c-c972-46ed-8087-d7d2517bac05",
+            "downsampling": {
+              "gridAggregation": "GRID_AGGREGATION_UNSPECIFIED",
+              "gapFilling": "GAP_FILLING_UNSPECIFIED"
+            },
+            "type": "monitoring"
+          }
+        ],
+        "seriesOverrides": [],
+        "overlays": [],
+        "id": "zvenfit-functions-throttles",
+        "visualizationSettings": {
+          "type": "VISUALIZATION_TYPE_UNSPECIFIED",
+          "normalize": false,
+          "interpolate": "INTERPOLATE_UNSPECIFIED",
+          "aggregation": "SERIES_AGGREGATION_UNSPECIFIED",
+          "colorSchemeSettings": {
+            "automatic": {},
+            "scheme": "automatic"
+          },
+          "heatmapSettings": null,
+          "yaxisSettings": {
+            "left": {
+              "type": "YAXIS_TYPE_LINEAR",
+              "title": "Ограничений",
+              "min": "",
+              "max": "",
+              "unitFormat": "UNIT_FORMAT_UNSPECIFIED",
+              "precision": null
+            },
+            "right": {
+              "type": "YAXIS_TYPE_LINEAR",
+              "title": "",
+              "min": "",
+              "max": "",
+              "unitFormat": "UNIT_FORMAT_UNSPECIFIED",
+              "precision": null
+            }
+          },
+          "title": "",
+          "showLabels": true,
+          "tilesSettings": null,
+          "hidePartialData": false
+        },
+        "nameHidingSettings": null,
+        "description": "",
+        "title": "Cloud Functions: ограничения запуска",
+        "displayLegend": true,
+        "freeze": "FREEZE_DURATION_UNSPECIFIED",
+        "repeat": null,
+        "thresholds": {
+          "items": [
+            {
+              "color": "#92db00",
+              "id": "b605e22a-44ef-4ab8-adf0-0f035811bdce"
+            }
+          ],
+          "showMode": "CONSTANT_LINE"
+        },
+        "eventSources": null,
+        "legendSettings": {
+          "sortRules": [],
+          "position": "POSITION_BOTTOM",
+          "truncate": "TRUNCATE_END",
+          "size": null,
+          "list": {
+            "columnsCount": 0
+          },
+          "view": "list"
+        }
+      },
+      "widget": "multiSourceChart"
+    },
+    {
+      "links": [],
+      "position": {
+        "x": "18",
+        "y": "48",
+        "w": "18",
+        "h": "8"
+      },
+      "multiSourceChart": {
+        "targets": [
+          {
+            "dataSourceId": "37bb817c-c972-46ed-8087-d7d2517bac05",
+            "query": "{project = \"folder__b1ge1e4iopttj79hfdfm\", service = \"serverless-functions\", name = \"functions_max_queue_duration\", resource_id = \"zvenfit-telegram-lead|zvenfit-fitbase-schedule|zvenfit-site-traffic\"}",
+            "textMode": true,
+            "hidden": false,
+            "name": "A",
+            "type": "monitoring"
+          }
+        ],
+        "dataSources": [
+          {
+            "id": "37bb817c-c972-46ed-8087-d7d2517bac05",
+            "downsampling": {
+              "gridAggregation": "GRID_AGGREGATION_UNSPECIFIED",
+              "gapFilling": "GAP_FILLING_UNSPECIFIED"
+            },
+            "type": "monitoring"
+          }
+        ],
+        "seriesOverrides": [],
+        "overlays": [],
+        "id": "zvenfit-functions-queue",
+        "visualizationSettings": {
+          "type": "VISUALIZATION_TYPE_UNSPECIFIED",
+          "normalize": false,
+          "interpolate": "INTERPOLATE_UNSPECIFIED",
+          "aggregation": "SERIES_AGGREGATION_UNSPECIFIED",
+          "colorSchemeSettings": {
+            "automatic": {},
+            "scheme": "automatic"
+          },
+          "heatmapSettings": null,
+          "yaxisSettings": {
+            "left": {
+              "type": "YAXIS_TYPE_LINEAR",
+              "title": "мс",
+              "min": "",
+              "max": "",
+              "unitFormat": "UNIT_FORMAT_UNSPECIFIED",
+              "precision": null
+            },
+            "right": {
+              "type": "YAXIS_TYPE_LINEAR",
+              "title": "",
+              "min": "",
+              "max": "",
+              "unitFormat": "UNIT_FORMAT_UNSPECIFIED",
+              "precision": null
+            }
+          },
+          "title": "",
+          "showLabels": true,
+          "tilesSettings": null,
+          "hidePartialData": false
+        },
+        "nameHidingSettings": null,
+        "description": "",
+        "title": "Cloud Functions: максимум ожидания в очереди",
+        "displayLegend": true,
+        "freeze": "FREEZE_DURATION_UNSPECIFIED",
+        "repeat": null,
+        "thresholds": {
+          "items": [
+            {
+              "color": "#92db00",
+              "id": "f824595c-be28-4a2f-8451-2638e56b0676"
+            }
+          ],
+          "showMode": "CONSTANT_LINE"
+        },
+        "eventSources": null,
+        "legendSettings": {
+          "sortRules": [],
+          "position": "POSITION_BOTTOM",
+          "truncate": "TRUNCATE_END",
+          "size": null,
+          "list": {
+            "columnsCount": 0
+          },
+          "view": "list"
+        }
+      },
+      "widget": "multiSourceChart"
+    },
+    {
+      "links": [],
+      "position": {
+        "x": "0",
+        "y": "56",
+        "w": "18",
+        "h": "8"
+      },
+      "multiSourceChart": {
+        "targets": [
+          {
+            "dataSourceId": "37bb817c-c972-46ed-8087-d7d2517bac05",
+            "query": "{project = \"folder__b1ge1e4iopttj79hfdfm\", service = \"serverless-functions\", name = \"functions_inflight\", resource_id = \"zvenfit-telegram-lead|zvenfit-fitbase-schedule|zvenfit-site-traffic\"}",
+            "textMode": true,
+            "hidden": false,
+            "name": "A",
+            "type": "monitoring"
+          }
+        ],
+        "dataSources": [
+          {
+            "id": "37bb817c-c972-46ed-8087-d7d2517bac05",
+            "downsampling": {
+              "gridAggregation": "GRID_AGGREGATION_UNSPECIFIED",
+              "gapFilling": "GAP_FILLING_UNSPECIFIED"
+            },
+            "type": "monitoring"
+          }
+        ],
+        "seriesOverrides": [],
+        "overlays": [],
+        "id": "zvenfit-functions-inflight",
+        "visualizationSettings": {
+          "type": "VISUALIZATION_TYPE_UNSPECIFIED",
+          "normalize": false,
+          "interpolate": "INTERPOLATE_UNSPECIFIED",
+          "aggregation": "SERIES_AGGREGATION_UNSPECIFIED",
+          "colorSchemeSettings": {
+            "automatic": {},
+            "scheme": "automatic"
+          },
+          "heatmapSettings": null,
+          "yaxisSettings": {
+            "left": {
+              "type": "YAXIS_TYPE_LINEAR",
+              "title": "Вызовов",
+              "min": "",
+              "max": "",
+              "unitFormat": "UNIT_FORMAT_UNSPECIFIED",
+              "precision": null
+            },
+            "right": {
+              "type": "YAXIS_TYPE_LINEAR",
+              "title": "",
+              "min": "",
+              "max": "",
+              "unitFormat": "UNIT_FORMAT_UNSPECIFIED",
+              "precision": null
+            }
+          },
+          "title": "",
+          "showLabels": true,
+          "tilesSettings": null,
+          "hidePartialData": false
+        },
+        "nameHidingSettings": null,
+        "description": "",
+        "title": "Cloud Functions: одновременные вызовы",
+        "displayLegend": true,
+        "freeze": "FREEZE_DURATION_UNSPECIFIED",
+        "repeat": null,
+        "thresholds": {
+          "items": [
+            {
+              "color": "#92db00",
+              "id": "60efc3bb-3384-4c8a-aecc-39e2e112c15a"
+            }
+          ],
+          "showMode": "CONSTANT_LINE"
+        },
+        "eventSources": null,
+        "legendSettings": {
+          "sortRules": [],
+          "position": "POSITION_BOTTOM",
+          "truncate": "TRUNCATE_END",
+          "size": null,
+          "list": {
+            "columnsCount": 0
+          },
+          "view": "list"
+        }
+      },
+      "widget": "multiSourceChart"
+    },
+    {
+      "links": [],
+      "position": {
+        "x": "18",
+        "y": "56",
+        "w": "18",
+        "h": "8"
+      },
+      "multiSourceChart": {
+        "targets": [
+          {
+            "dataSourceId": "37bb817c-c972-46ed-8087-d7d2517bac05",
+            "query": "{project = \"folder__b1ge1e4iopttj79hfdfm\", service = \"serverless-functions\", name = \"functions_max_memory\", resource_id = \"zvenfit-telegram-lead|zvenfit-fitbase-schedule|zvenfit-site-traffic\"}",
+            "textMode": true,
+            "hidden": false,
+            "name": "A",
+            "type": "monitoring"
+          }
+        ],
+        "dataSources": [
+          {
+            "id": "37bb817c-c972-46ed-8087-d7d2517bac05",
+            "downsampling": {
+              "gridAggregation": "GRID_AGGREGATION_UNSPECIFIED",
+              "gapFilling": "GAP_FILLING_UNSPECIFIED"
+            },
+            "type": "monitoring"
+          }
+        ],
+        "seriesOverrides": [],
+        "overlays": [],
+        "id": "zvenfit-functions-memory",
+        "visualizationSettings": {
+          "type": "VISUALIZATION_TYPE_UNSPECIFIED",
+          "normalize": false,
+          "interpolate": "INTERPOLATE_UNSPECIFIED",
+          "aggregation": "SERIES_AGGREGATION_UNSPECIFIED",
+          "colorSchemeSettings": {
+            "automatic": {},
+            "scheme": "automatic"
+          },
+          "heatmapSettings": null,
+          "yaxisSettings": {
+            "left": {
+              "type": "YAXIS_TYPE_LINEAR",
+              "title": "Байт",
+              "min": "",
+              "max": "",
+              "unitFormat": "UNIT_FORMAT_UNSPECIFIED",
+              "precision": null
+            },
+            "right": {
+              "type": "YAXIS_TYPE_LINEAR",
+              "title": "",
+              "min": "",
+              "max": "",
+              "unitFormat": "UNIT_FORMAT_UNSPECIFIED",
+              "precision": null
+            }
+          },
+          "title": "",
+          "showLabels": true,
+          "tilesSettings": null,
+          "hidePartialData": false
+        },
+        "nameHidingSettings": null,
+        "description": "",
+        "title": "Cloud Functions: максимум памяти",
+        "displayLegend": true,
+        "freeze": "FREEZE_DURATION_UNSPECIFIED",
+        "repeat": null,
+        "thresholds": {
+          "items": [
+            {
+              "color": "#92db00",
+              "id": "82fcf8ed-076b-45ca-8f23-4803b5ca612d"
+            }
+          ],
+          "showMode": "CONSTANT_LINE"
+        },
+        "eventSources": null,
+        "legendSettings": {
+          "sortRules": [],
+          "position": "POSITION_BOTTOM",
+          "truncate": "TRUNCATE_END",
+          "size": null,
+          "list": {
+            "columnsCount": 0
+          },
+          "view": "list"
+        }
+      },
+      "widget": "multiSourceChart"
+    },
+    {
+      "links": [],
+      "position": {
+        "x": "0",
+        "y": "64",
+        "w": "18",
+        "h": "8"
+      },
+      "multiSourceChart": {
+        "targets": [
+          {
+            "dataSourceId": "37bb817c-c972-46ed-8087-d7d2517bac05",
+            "query": "histogram_percentile(95, {project=\"folder__b1ge1e4iopttj79hfdfm\", service=\"serverless-functions\", name=\"duration_ms_histogram\", resource_id=\"zvenfit-telegram-lead|zvenfit-fitbase-schedule|zvenfit-site-traffic\"})",
+            "textMode": true,
+            "hidden": false,
+            "name": "A",
+            "type": "monitoring"
+          }
+        ],
+        "dataSources": [
+          {
+            "id": "37bb817c-c972-46ed-8087-d7d2517bac05",
+            "downsampling": {
+              "gridAggregation": "GRID_AGGREGATION_UNSPECIFIED",
+              "gapFilling": "GAP_FILLING_UNSPECIFIED"
+            },
+            "type": "monitoring"
+          }
+        ],
+        "seriesOverrides": [],
+        "overlays": [],
+        "id": "zvenfit-functions-duration",
+        "visualizationSettings": {
+          "type": "VISUALIZATION_TYPE_UNSPECIFIED",
+          "normalize": false,
+          "interpolate": "INTERPOLATE_UNSPECIFIED",
+          "aggregation": "SERIES_AGGREGATION_UNSPECIFIED",
+          "colorSchemeSettings": {
+            "automatic": {},
+            "scheme": "automatic"
+          },
+          "heatmapSettings": null,
+          "yaxisSettings": {
+            "left": {
+              "type": "YAXIS_TYPE_LINEAR",
+              "title": "мс",
+              "min": "",
+              "max": "",
+              "unitFormat": "UNIT_FORMAT_UNSPECIFIED",
+              "precision": null
+            },
+            "right": {
+              "type": "YAXIS_TYPE_LINEAR",
+              "title": "",
+              "min": "",
+              "max": "",
+              "unitFormat": "UNIT_FORMAT_UNSPECIFIED",
+              "precision": null
+            }
+          },
+          "title": "",
+          "showLabels": true,
+          "tilesSettings": null,
+          "hidePartialData": false
+        },
+        "nameHidingSettings": null,
+        "description": "",
+        "title": "Cloud Functions: длительность p95",
+        "displayLegend": true,
+        "freeze": "FREEZE_DURATION_UNSPECIFIED",
+        "repeat": null,
+        "thresholds": {
+          "items": [
+            {
+              "color": "#92db00",
+              "id": "f6581c99-442c-4846-9277-a4684c2d06bb"
+            }
+          ],
+          "showMode": "CONSTANT_LINE"
+        },
+        "eventSources": null,
+        "legendSettings": {
+          "sortRules": [],
+          "position": "POSITION_BOTTOM",
+          "truncate": "TRUNCATE_END",
+          "size": null,
+          "list": {
+            "columnsCount": 0
+          },
+          "view": "list"
+        }
+      },
+      "widget": "multiSourceChart"
+    },
+    {
+      "links": [],
+      "position": {
+        "x": "0",
+        "y": "72",
+        "w": "36",
+        "h": "2"
+      },
+      "title": {
+        "text": "Технический трафик сайта",
+        "size": "TITLE_SIZE_L"
+      },
+      "widget": "title"
+    },
+    {
+      "links": [],
+      "position": {
+        "x": "0",
+        "y": "74",
+        "w": "18",
+        "h": "8"
+      },
+      "multiSourceChart": {
+        "targets": [
+          {
+            "dataSourceId": "1ec81c70-e1f4-4509-bff1-af9b94941c1c",
+            "query": "edge.requests{service=\"yccdn\",resource=\"bc8rubabuwzpqqp7rifz\"}",
+            "textMode": true,
+            "hidden": false,
+            "name": "A",
+            "type": "monitoring"
+          }
+        ],
+        "dataSources": [
+          {
+            "id": "1ec81c70-e1f4-4509-bff1-af9b94941c1c",
+            "downsampling": {
+              "gridAggregation": "GRID_AGGREGATION_UNSPECIFIED",
+              "gapFilling": "GAP_FILLING_UNSPECIFIED"
+            },
+            "type": "monitoring"
+          }
+        ],
+        "seriesOverrides": [],
+        "overlays": [],
+        "id": "e060e81c-0fbd-46df-9986-a57e07915f7f",
+        "visualizationSettings": {
+          "type": "VISUALIZATION_TYPE_UNSPECIFIED",
+          "normalize": false,
+          "interpolate": "INTERPOLATE_UNSPECIFIED",
+          "aggregation": "SERIES_AGGREGATION_UNSPECIFIED",
+          "colorSchemeSettings": {
+            "automatic": {},
+            "scheme": "automatic"
+          },
+          "heatmapSettings": null,
+          "yaxisSettings": {
+            "left": {
+              "type": "YAXIS_TYPE_LINEAR",
+              "title": "",
+              "min": "",
+              "max": "",
+              "unitFormat": "UNIT_FORMAT_UNSPECIFIED",
+              "precision": null
+            },
+            "right": {
+              "type": "YAXIS_TYPE_LINEAR",
+              "title": "",
+              "min": "",
+              "max": "",
+              "unitFormat": "UNIT_FORMAT_UNSPECIFIED",
+              "precision": null
+            }
+          },
+          "title": "",
+          "showLabels": false,
+          "tilesSettings": null,
+          "hidePartialData": false
+        },
+        "nameHidingSettings": null,
+        "description": "",
+        "title": "Cloud CDN: запросы",
+        "displayLegend": false,
+        "freeze": "FREEZE_DURATION_UNSPECIFIED",
+        "repeat": null,
+        "thresholds": {
+          "items": [
+            {
+              "color": "#92db00",
+              "id": "8c0d1e08-ded2-4230-a45e-7c0ae7dfb598"
+            }
+          ],
+          "showMode": "CONSTANT_LINE"
+        },
+        "eventSources": null,
+        "legendSettings": {
+          "sortRules": [],
+          "position": "POSITION_BOTTOM",
+          "truncate": "TRUNCATE_END",
+          "size": null,
+          "list": {
+            "columnsCount": 0
+          },
+          "view": "list"
+        }
+      },
+      "widget": "multiSourceChart"
+    },
+    {
+      "links": [],
+      "position": {
+        "x": "18",
+        "y": "74",
+        "w": "18",
+        "h": "8"
+      },
+      "multiSourceChart": {
+        "targets": [
+          {
+            "dataSourceId": "8ebd4104-6f61-4889-b122-ee2be60c8f5c",
+            "query": "edge.requests_status{service=\"yccdn\",resource=\"bc8rubabuwzpqqp7rifz\"}",
+            "textMode": true,
+            "hidden": false,
+            "name": "A",
+            "type": "monitoring"
+          }
+        ],
+        "dataSources": [
+          {
+            "id": "8ebd4104-6f61-4889-b122-ee2be60c8f5c",
+            "downsampling": {
+              "gridAggregation": "GRID_AGGREGATION_UNSPECIFIED",
+              "gapFilling": "GAP_FILLING_UNSPECIFIED"
+            },
+            "type": "monitoring"
+          }
+        ],
+        "seriesOverrides": [],
+        "overlays": [],
+        "id": "eeccc03f-4944-47ea-a9a7-038e3c0dfa9e",
+        "visualizationSettings": {
+          "type": "VISUALIZATION_TYPE_UNSPECIFIED",
+          "normalize": false,
+          "interpolate": "INTERPOLATE_UNSPECIFIED",
+          "aggregation": "SERIES_AGGREGATION_UNSPECIFIED",
+          "colorSchemeSettings": {
+            "automatic": {},
+            "scheme": "automatic"
+          },
+          "heatmapSettings": null,
+          "yaxisSettings": {
+            "left": {
+              "type": "YAXIS_TYPE_LINEAR",
+              "title": "",
+              "min": "",
+              "max": "",
+              "unitFormat": "UNIT_FORMAT_UNSPECIFIED",
+              "precision": null
+            },
+            "right": {
+              "type": "YAXIS_TYPE_LINEAR",
+              "title": "",
+              "min": "",
+              "max": "",
+              "unitFormat": "UNIT_FORMAT_UNSPECIFIED",
+              "precision": null
+            }
+          },
+          "title": "",
+          "showLabels": false,
+          "tilesSettings": null,
+          "hidePartialData": false
+        },
+        "nameHidingSettings": null,
+        "description": "",
+        "title": "Cloud CDN: HTTP-статусы",
+        "displayLegend": false,
+        "freeze": "FREEZE_DURATION_UNSPECIFIED",
+        "repeat": null,
+        "thresholds": {
+          "items": [
+            {
+              "color": "#92db00",
+              "id": "3ab3ef85-e192-42f8-a079-cfdaa67d7605"
+            }
+          ],
+          "showMode": "CONSTANT_LINE"
+        },
+        "eventSources": null,
+        "legendSettings": {
+          "sortRules": [],
+          "position": "POSITION_BOTTOM",
+          "truncate": "TRUNCATE_END",
+          "size": null,
+          "list": {
+            "columnsCount": 0
+          },
+          "view": "list"
+        }
+      },
+      "widget": "multiSourceChart"
+    },
+    {
+      "links": [],
+      "position": {
+        "x": "0",
+        "y": "82",
+        "w": "18",
+        "h": "8"
+      },
+      "multiSourceChart": {
+        "targets": [
+          {
+            "dataSourceId": "474294b5-603d-4d2e-88dd-e0c74ee9305b",
+            "query": "{project=\"folder__b1ge1e4iopttj79hfdfm\", service=\"logging_aggregates\", cluster=\"default\", name=\"zvenfit_site_page_views_by_class_5m\"}",
+            "textMode": true,
+            "hidden": false,
+            "name": "A",
+            "type": "monitoring"
+          }
+        ],
+        "dataSources": [
+          {
+            "id": "474294b5-603d-4d2e-88dd-e0c74ee9305b",
+            "downsampling": {
+              "gridAggregation": "GRID_AGGREGATION_UNSPECIFIED",
+              "gapFilling": "GAP_FILLING_UNSPECIFIED",
+              "maxPoints": "100",
+              "mode": "maxPoints"
+            },
+            "type": "monitoring"
+          }
+        ],
+        "seriesOverrides": [],
+        "overlays": [],
+        "id": "7pHUyXLujL-taqAdWUXqh",
+        "visualizationSettings": {
+          "type": "VISUALIZATION_TYPE_TILES",
+          "normalize": false,
+          "interpolate": "INTERPOLATE_UNSPECIFIED",
+          "aggregation": "SERIES_AGGREGATION_LAST",
+          "colorSchemeSettings": {
+            "automatic": {},
+            "scheme": "automatic"
+          },
+          "heatmapSettings": null,
+          "yaxisSettings": {
+            "left": {
+              "type": "YAXIS_TYPE_LINEAR",
+              "title": "",
+              "min": "",
+              "max": "",
+              "unitFormat": "UNIT_FORMAT_UNSPECIFIED",
+              "precision": null
+            },
+            "right": {
+              "type": "YAXIS_TYPE_LINEAR",
+              "title": "",
+              "min": "",
+              "max": "",
+              "unitFormat": "UNIT_FORMAT_UNSPECIFIED",
+              "precision": null
+            }
+          },
+          "title": "",
+          "showLabels": false,
+          "tilesSettings": {
+            "sortOrder": "ASC",
+            "sortField": "VALUE",
+            "showTitle": false,
+            "showValue": true,
+            "showSparkline": false
+          },
+          "hidePartialData": false
+        },
+        "nameHidingSettings": null,
+        "description": "",
+        "title": "Просмотры страниц за 5 минут",
+        "displayLegend": false,
+        "freeze": "FREEZE_DURATION_UNSPECIFIED",
+        "repeat": null,
+        "thresholds": {
+          "items": [
+            {
+              "color": "#92db00",
+              "id": "6b21c1c1-415e-4ccf-b2a0-762838ab7fb0"
+            }
+          ],
+          "showMode": "CONSTANT_LINE"
+        },
+        "eventSources": null,
+        "legendSettings": {
+          "sortRules": [],
+          "position": "POSITION_BOTTOM",
+          "truncate": "TRUNCATE_END",
+          "size": null,
+          "list": {
+            "columnsCount": 0
+          },
+          "view": "list"
+        }
+      },
+      "widget": "multiSourceChart"
+    },
+    {
+      "links": [],
+      "position": {
+        "x": "18",
+        "y": "82",
+        "w": "18",
+        "h": "8"
+      },
+      "multiSourceChart": {
+        "targets": [
+          {
+            "dataSourceId": "474294b5-603d-4d2e-88dd-e0c74ee9305b",
+            "query": "{project = \"folder__b1ge1e4iopttj79hfdfm\", service = \"logging_aggregates\", cluster = \"default\", name = \"zvenfit_site_page_views_by_class_5m\"}",
+            "textMode": false,
+            "hidden": false,
+            "name": "A",
+            "type": "monitoring"
+          }
+        ],
+        "dataSources": [
+          {
+            "id": "474294b5-603d-4d2e-88dd-e0c74ee9305b",
+            "downsampling": {
+              "gridAggregation": "GRID_AGGREGATION_UNSPECIFIED",
+              "gapFilling": "GAP_FILLING_UNSPECIFIED"
+            },
+            "type": "monitoring"
+          }
+        ],
+        "seriesOverrides": [],
+        "overlays": [],
+        "id": "4d3c58ca-2fe4-4618-a8ab-c11d4b3e474b",
+        "visualizationSettings": {
+          "type": "VISUALIZATION_TYPE_UNSPECIFIED",
+          "normalize": false,
+          "interpolate": "INTERPOLATE_UNSPECIFIED",
+          "aggregation": "SERIES_AGGREGATION_UNSPECIFIED",
+          "colorSchemeSettings": {
+            "automatic": {},
+            "scheme": "automatic"
+          },
+          "heatmapSettings": null,
+          "yaxisSettings": {
+            "left": {
+              "type": "YAXIS_TYPE_LINEAR",
+              "title": "",
+              "min": "",
+              "max": "",
+              "unitFormat": "UNIT_FORMAT_UNSPECIFIED",
+              "precision": null
+            },
+            "right": {
+              "type": "YAXIS_TYPE_LINEAR",
+              "title": "",
+              "min": "",
+              "max": "",
+              "unitFormat": "UNIT_FORMAT_UNSPECIFIED",
+              "precision": null
+            }
+          },
+          "title": "",
+          "showLabels": false,
+          "tilesSettings": null,
+          "hidePartialData": false
+        },
+        "nameHidingSettings": null,
+        "description": "",
+        "title": "Просмотры страниц по классам трафика",
+        "displayLegend": false,
+        "freeze": "FREEZE_DURATION_UNSPECIFIED",
+        "repeat": null,
+        "thresholds": {
+          "items": [
+            {
+              "color": "#92db00",
+              "id": "13d140a6-fbad-444c-9c2f-6e215bc5d816"
+            }
+          ],
+          "showMode": "CONSTANT_LINE"
+        },
+        "eventSources": null,
+        "legendSettings": {
+          "sortRules": [],
+          "position": "POSITION_BOTTOM",
+          "truncate": "TRUNCATE_END",
+          "size": null,
+          "list": {
+            "columnsCount": 0
+          },
+          "view": "list"
+        }
+      },
+      "widget": "multiSourceChart"
+    },
+    {
+      "links": [],
+      "position": {
+        "x": "0",
+        "y": "90",
+        "w": "12",
+        "h": "8"
+      },
+      "multiSourceChart": {
+        "targets": [
+          {
+            "dataSourceId": "0d8766d6-efce-4a88-8da7-a88632f980a7",
+            "query": "series_sum({project=\"folder__b1ge1e4iopttj79hfdfm\", cluster=\"default\", service=\"logging_aggregates\", name=\"zvenfit_retry_worker_log_heartbeat_1m\"})",
+            "textMode": true,
+            "hidden": false,
+            "name": "A",
+            "type": "monitoring"
+          }
+        ],
+        "dataSources": [
+          {
+            "id": "0d8766d6-efce-4a88-8da7-a88632f980a7",
+            "downsampling": {
+              "gridAggregation": "GRID_AGGREGATION_UNSPECIFIED",
+              "gapFilling": "GAP_FILLING_UNSPECIFIED"
+            },
+            "type": "monitoring"
+          }
+        ],
+        "seriesOverrides": [],
+        "overlays": [],
+        "id": "00b84d7f-b989-43bc-9bf4-f80506c13970",
+        "visualizationSettings": {
+          "type": "VISUALIZATION_TYPE_UNSPECIFIED",
+          "normalize": false,
+          "interpolate": "INTERPOLATE_UNSPECIFIED",
+          "aggregation": "SERIES_AGGREGATION_UNSPECIFIED",
+          "colorSchemeSettings": {
+            "automatic": {},
+            "scheme": "automatic"
+          },
+          "heatmapSettings": null,
+          "yaxisSettings": {
+            "left": {
+              "type": "YAXIS_TYPE_LINEAR",
+              "title": "",
+              "min": "",
+              "max": "",
+              "unitFormat": "UNIT_FORMAT_UNSPECIFIED",
+              "precision": null
+            },
+            "right": {
+              "type": "YAXIS_TYPE_LINEAR",
+              "title": "",
+              "min": "",
+              "max": "",
+              "unitFormat": "UNIT_FORMAT_UNSPECIFIED",
+              "precision": null
+            }
+          },
+          "title": "",
+          "showLabels": false,
+          "tilesSettings": null,
+          "hidePartialData": false
+        },
+        "nameHidingSettings": null,
+        "description": "",
+        "title": "Поставка событий: heartbeat retry-worker",
+        "displayLegend": false,
+        "freeze": "FREEZE_DURATION_UNSPECIFIED",
+        "repeat": null,
+        "thresholds": {
+          "items": [
+            {
+              "color": "#92db00",
+              "id": "1366f24c-2666-40c2-95e8-8f9ec88ee03b"
+            }
+          ],
+          "showMode": "CONSTANT_LINE"
+        },
+        "eventSources": null,
+        "legendSettings": {
+          "sortRules": [],
+          "position": "POSITION_BOTTOM",
+          "truncate": "TRUNCATE_END",
+          "size": null,
+          "list": {
+            "columnsCount": 0
+          },
+          "view": "list"
+        }
+      },
+      "widget": "multiSourceChart"
+    }
+  ],
+  "links": [],
+  "overlays": [],
+  "presetItems": []
+}


### PR DESCRIPTION
## Что изменено
- добавлен штатный JSON-export production dashboard как восстанавливаемый Git artifact
- live dashboard обновлён через JSON-import: добавлены быстрые ссылки INFO/ERROR
- desired state синхронизирован с live grouping taxonomy и фактическими traffic widgets
- добавлены проверки import artifact, quick links и groupBy/filter invariant
- обновлены monitoring docs и project KB

## Проверки
- npm run test:monitoring — 33/33
- git diff --check
- dashboard JSON parse/PII/secret checks
- повторный live export после import