### PR TITLE
Fix monitoring dashboard tile alignment

### DIFF
--- a/knowledge-base/dashboards.md
+++ b/knowledge-base/dashboards.md
@@ -15,6 +15,9 @@ updated: 2026-08-16
   monitoring runbook.
 - Empty event graphs are normal while the corresponding alert is green.
 - Refresh interval: one minute.
+- Layout grid: 36 columns. Paired charts use 18 columns each; when a section has
+  an unpaired final chart, it spans all 36 columns so the section ends without
+  a ragged empty area.
 
 ## Backup and restore
 

--- a/scripts/__tests__/monitoring-config.test.cjs
+++ b/scripts/__tests__/monitoring-config.test.cjs
@@ -96,6 +96,19 @@ test('native dashboard JSON is restorable and matches critical desired-state inv
   assert.ok(chartTitles.includes('Cloud Functions: длительность p95'));
   assert.ok(chartTitles.includes('Поставка событий: heartbeat retry-worker'));
 
+  for (const title of [
+    'Cloud Functions: длительность p95',
+    'Поставка событий: heartbeat retry-worker',
+  ]) {
+    const widget = dashboardExport.widgets.find(item => item.multiSourceChart?.title === title);
+    assert.deepEqual(widget.position, {
+      x: '0',
+      y: title === 'Cloud Functions: длительность p95' ? '64' : '90',
+      w: '36',
+      h: '8',
+    });
+  }
+
   assert.doesNotMatch(dashboardExportText, /authorization|bearer\s|api[_-]?key|password|secret/i);
   assert.doesNotMatch(dashboardExportText, /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/i);
 });
@@ -504,11 +517,13 @@ test('dashboard includes diagnostic p95 duration and an independent log-pipeline
   assert.match(duration.query, /zvenfit-site-traffic/);
   assert.deepEqual(duration.decomposeBy, ['resource_id']);
   assert.equal(duration.pagingAlert, false);
+  assert.deepEqual(duration.layout, { widthColumns: 36, heightRows: 8 });
 
   assert.equal(logHeartbeat.source, 'zvenfit_retry_worker_log_heartbeat_1m');
   assert.match(logHeartbeat.query, /service="logging_aggregates"/);
   assert.match(logHeartbeat.query, /name="zvenfit_retry_worker_log_heartbeat_1m"/);
   assert.equal(logHeartbeat.pagingAlert, false);
+  assert.deepEqual(logHeartbeat.layout, { widthColumns: 36, heightRows: 8 });
 });
 
 test('rate limiter fail-open path has a count-based health alert', () => {

--- a/scripts/monitoring.config.json
+++ b/scripts/monitoring.config.json
@@ -95,14 +95,22 @@
       "query": "histogram_percentile(95, {project=\"folder__b1ge1e4iopttj79hfdfm\", service=\"serverless-functions\", name=\"duration_ms_histogram\", resource_id=\"zvenfit-telegram-lead|zvenfit-fitbase-schedule|zvenfit-site-traffic\"})",
       "unit": "milliseconds",
       "pagingAlert": false,
-      "decomposeBy": ["resource_id"]
+      "decomposeBy": ["resource_id"],
+      "layout": {
+        "widthColumns": 36,
+        "heightRows": 8
+      }
     },
     "logPipelineHeartbeat": {
       "title": "Поставка событий: heartbeat retry-worker",
       "source": "zvenfit_retry_worker_log_heartbeat_1m",
       "query": "series_sum({project=\"folder__b1ge1e4iopttj79hfdfm\", cluster=\"default\", service=\"logging_aggregates\", name=\"zvenfit_retry_worker_log_heartbeat_1m\"})",
       "visualization": "chart",
-      "pagingAlert": false
+      "pagingAlert": false,
+      "layout": {
+        "widthColumns": 36,
+        "heightRows": 8
+      }
     },
     "trafficWidgets": [
       "Cloud CDN: запросы",

--- a/scripts/monitoring.dashboard.json
+++ b/scripts/monitoring.dashboard.json
@@ -148,7 +148,7 @@
           "items": [
             {
               "color": "#92db00",
-              "id": "c19f1e44-d054-463a-a1c1-e33102a6c5de"
+              "id": "c93f3518-227e-4230-94ed-a1f64dd8c5b3"
             }
           ],
           "showMode": "CONSTANT_LINE"
@@ -242,7 +242,7 @@
           "items": [
             {
               "color": "#92db00",
-              "id": "b605e200-719c-4964-9fe0-9e3d4920a097"
+              "id": "2ba3c6fc-f38f-40e1-a5e4-45919d5bda44"
             }
           ],
           "showMode": "CONSTANT_LINE"
@@ -336,7 +336,7 @@
           "items": [
             {
               "color": "#92db00",
-              "id": "0ddb4a0a-ccd1-4c9f-84a7-23a2fda52227"
+              "id": "01ed178b-5084-4090-b033-5e7626a6e03e"
             }
           ],
           "showMode": "CONSTANT_LINE"
@@ -430,7 +430,7 @@
           "items": [
             {
               "color": "#92db00",
-              "id": "48043cf9-f5aa-4795-b0d3-2496981215cc"
+              "id": "faf355a7-3067-4a8f-92e5-d5bf9a4104f1"
             }
           ],
           "showMode": "CONSTANT_LINE"
@@ -524,7 +524,7 @@
           "items": [
             {
               "color": "#92db00",
-              "id": "21b5dee0-a37c-4171-87b1-2f9b3763f3a7"
+              "id": "888ad595-ac57-4ff0-9fd3-d4d25bdeb9ca"
             }
           ],
           "showMode": "CONSTANT_LINE"
@@ -618,7 +618,7 @@
           "items": [
             {
               "color": "#92db00",
-              "id": "ffbbe16a-91a3-4ff3-8183-9675b0725640"
+              "id": "e2aaaf34-8089-4f82-8804-589107dfb35b"
             }
           ],
           "showMode": "CONSTANT_LINE"
@@ -712,7 +712,7 @@
           "items": [
             {
               "color": "#92db00",
-              "id": "9b7d6bfe-e730-4570-bdec-291a3f64d850"
+              "id": "593cc783-4754-4211-97f3-0074516a071e"
             }
           ],
           "showMode": "CONSTANT_LINE"
@@ -814,7 +814,7 @@
           "items": [
             {
               "color": "#92db00",
-              "id": "ff80611f-358e-45a3-8f23-d51c1c56206d"
+              "id": "7e83840e-6907-4dfc-b0c8-aa9b1c86205c"
             }
           ],
           "showMode": "CONSTANT_LINE"
@@ -922,7 +922,7 @@
           "items": [
             {
               "color": "#92db00",
-              "id": "b605e22a-44ef-4ab8-adf0-0f035811bdce"
+              "id": "876edb46-798e-41bc-81a4-809614608595"
             }
           ],
           "showMode": "CONSTANT_LINE"
@@ -1016,7 +1016,7 @@
           "items": [
             {
               "color": "#92db00",
-              "id": "f824595c-be28-4a2f-8451-2638e56b0676"
+              "id": "3406b40e-2c96-4f8d-be6f-0a59788b11cf"
             }
           ],
           "showMode": "CONSTANT_LINE"
@@ -1110,7 +1110,7 @@
           "items": [
             {
               "color": "#92db00",
-              "id": "60efc3bb-3384-4c8a-aecc-39e2e112c15a"
+              "id": "359ab610-e78a-4997-9967-601923774c0a"
             }
           ],
           "showMode": "CONSTANT_LINE"
@@ -1204,7 +1204,7 @@
           "items": [
             {
               "color": "#92db00",
-              "id": "82fcf8ed-076b-45ca-8f23-4803b5ca612d"
+              "id": "338b5a6f-9c0c-4fbe-b37f-df8d5b5eb690"
             }
           ],
           "showMode": "CONSTANT_LINE"
@@ -1228,7 +1228,7 @@
       "position": {
         "x": "0",
         "y": "64",
-        "w": "18",
+        "w": "36",
         "h": "8"
       },
       "multiSourceChart": {
@@ -1298,7 +1298,7 @@
           "items": [
             {
               "color": "#92db00",
-              "id": "f6581c99-442c-4846-9277-a4684c2d06bb"
+              "id": "4d0846b0-0862-4080-aa79-97c34ffc4124"
             }
           ],
           "showMode": "CONSTANT_LINE"
@@ -1406,7 +1406,7 @@
           "items": [
             {
               "color": "#92db00",
-              "id": "8c0d1e08-ded2-4230-a45e-7c0ae7dfb598"
+              "id": "e0c1913c-a1b6-4ba7-911c-77de378e73a0"
             }
           ],
           "showMode": "CONSTANT_LINE"
@@ -1500,7 +1500,7 @@
           "items": [
             {
               "color": "#92db00",
-              "id": "3ab3ef85-e192-42f8-a079-cfdaa67d7605"
+              "id": "ef615420-ebed-4040-98db-0b72962bc6a0"
             }
           ],
           "showMode": "CONSTANT_LINE"
@@ -1602,7 +1602,7 @@
           "items": [
             {
               "color": "#92db00",
-              "id": "6b21c1c1-415e-4ccf-b2a0-762838ab7fb0"
+              "id": "bd4c93fb-56a1-4824-a812-aa43c39d3de8"
             }
           ],
           "showMode": "CONSTANT_LINE"
@@ -1696,7 +1696,7 @@
           "items": [
             {
               "color": "#92db00",
-              "id": "13d140a6-fbad-444c-9c2f-6e215bc5d816"
+              "id": "90ea01a1-d67e-410d-a438-bb90e2469dcd"
             }
           ],
           "showMode": "CONSTANT_LINE"
@@ -1720,7 +1720,7 @@
       "position": {
         "x": "0",
         "y": "90",
-        "w": "12",
+        "w": "36",
         "h": "8"
       },
       "multiSourceChart": {
@@ -1790,7 +1790,7 @@
           "items": [
             {
               "color": "#92db00",
-              "id": "1366f24c-2666-40c2-95e8-8f9ec88ee03b"
+              "id": "681eeaf6-f38d-4113-9cb5-b6d08ae2f0d9"
             }
           ],
           "showMode": "CONSTANT_LINE"


### PR DESCRIPTION
## Что изменено
- два непарных последних графика растянуты на всю 36-колоночную сетку
- live Monium повторно экспортирован в canonical dashboard JSON
- layout закреплён в desired state и project KB
- добавлена regression-проверка позиций

## Проверки
- npm run test:monitoring (33/33)
- git diff --check
- визуальная проверка обеих секций в live Monium