### PR TITLE
fix: separate YDB session latency monitoring

### DIFF
--- a/docs/monitoring-operations.md
+++ b/docs/monitoring-operations.md
@@ -164,6 +164,9 @@ Runtime errors и throttling всех трёх функций покрывают
 на production-борде заменён, чтобы единичный выброс не искажал основной сигнал. Log-derived
 `zvenfit_retry_worker_log_heartbeat_1m` отдельно подтверждает поставку structured
 events и не создаёт второй paging-сигнал.
+YDB SQL latency считается только по фазе `query_execute`; медленные
+`session_acquire` и `session_create` выводятся отдельным диагностическим
+графиком без paging-alert.
 
 ## Разбор срабатывания
 

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -134,10 +134,11 @@ Lead/schedule автоматически скрывают известные п�
 | `telegram_delivery_retry_scheduled`    | Telegram временно недоступен, будет retry                    | Log only   |
 | `telegram_delivery_failed_permanently` | Исчерпаны попытки Telegram                                   | Critical   |
 | `retry_worker_completed`               | Минутный retry pass и чтение состояния очереди завершены     | Diagnostic |
-| `ydb_operation_completed`              | Длительность SQL-операции и число retry, без запуска клиента | Diagnostic |
+| `ydb_operation_completed`              | Полная длительность и разбивка query/session-фаз              | Diagnostic |
 | `ydb_retry`                            | YDB-клиент повторил операцию после временной ошибки          | Warning    |
 | `site_page_view`                       | Beacon страницы принят и классифицирован                     | Diagnostic |
-| `ydb_slow_operation`                   | Операция YDB превысила `YDB_SLOW_OPERATION_MS`               | Warning    |
+| `ydb_slow_operation`                   | `ExecuteQuery` превысил `YDB_SLOW_OPERATION_MS`              | Warning    |
+| `ydb_slow_session_phase`               | Получение или создание YDB-сессии превысило порог            | Diagnostic |
 | `ydb_operation_failed`                 | Операция YDB завершилась ошибкой                             | Critical   |
 | `fitbase_schedule_error`               | Fitbase вернул ошибку или недоступен                         | Warning    |
 | `fitbase_schedule_misconfigured`       | Для production Fitbase provider отсутствует token            | Critical   |
@@ -196,6 +197,26 @@ Lead/schedule автоматически скрывают известные п�
 ```text
 {project="folder__b1ge1e4iopttj79hfdfm", cluster="default", service="default", meta.application="zvenfit-frontend", meta.environment="production", message=*"ydb_slow_operation"}
 ```
+
+Событие создаётся только по длительности фактического `ExecuteQuery`. Получение
+сессии из пула, создание новой сессии, retry/backoff и инициализация driver в
+этот сигнал не входят.
+
+### 5a. Slow YDB session phases
+
+- ID: `zvenfit_ydb_slow_session_phases_5m`
+- Window: 5 minutes
+- Group by: `meta.phase`
+- Paging alert: none
+- Selector:
+
+```text
+{project="folder__b1ge1e4iopttj79hfdfm", cluster="default", service="default", meta.application="zvenfit-frontend", meta.environment="production", message=*"ydb_slow_session_phase"}
+```
+
+Диагностический график различает `session_acquire` и `session_create`. Он не
+отправляет уведомления: пользовательское влияние продолжают покрывать slow SQL,
+YDB errors/retries, heartbeat retry-worker и очередь доставки.
 
 ### 6. Rate-limited submissions
 
@@ -276,7 +297,9 @@ heartbeat указывает на проблему Cloud Logging/log aggregate, 
 доказать, что заявка была сохранена до разрыва соединения.
 
 Каждая операция также пишет `ydb_operation_completed` с полями `operation`,
-`duration_ms` и `retry_attempts`. Значения заявки и текст SQL в эти события не попадают.
+`duration_ms`, `retry_attempts` и агрегатами `query_execute_*`,
+`session_acquire_*`, `session_create_*`. Значения заявки, параметры и текст SQL
+в эти события не попадают.
 
 Исходные логи читаются из `service="default"`, а созданные агрегаты
 записываются в отдельный `service="logging_aggregates"`. Текущий шард использует
@@ -349,8 +372,10 @@ serverless-инвокации мог нормализовать `DELTA` counter 
 за 155 мс, дала direct metric `6.4516129` (`1 / 0.155`) и ложный `Alarm` вместо
 `Warning`. Log aggregate сохраняет для неё значение `1`. Latency операции
 измеряется после готовности YDB-клиента, чтобы холодное создание driver не
-выглядело как медленный SQL-запрос. Порог `YDB_SLOW_OPERATION_MS` относится
-именно к выполнению операции после инициализации клиента.
+выглядело как медленный SQL-запрос. После эпизодов 2026-08-16/17 измерение также
+разделено на `session_acquire`, `session_create` и `query_execute`: paging-событие
+`ydb_slow_operation` относится только к последней фазе, а медленные сессионные
+фазы пишутся как непейджинговый `ydb_slow_session_phase`.
 
 Точный селектор агрегата ошибок сохранения:
 
@@ -509,7 +534,8 @@ heartbeat, размер и возраст Telegram-очереди, а также
 histogram `duration_ms_histogram`, функцию `histogram_percentile(95, ...)` и
 разбивку по `resource_id`. Он заменяет прежний max duration: p95 лучше отражает
 типичную деградацию и не поднимается от единственного выброса. Для YDB отдельно
-выведи количество `ydb_retry`, `ydb_slow_operation` и `C` — процент
+выведи количество `ydb_retry`, `ydb_slow_operation`, диагностический
+`ydb_slow_session_phase` с разбивкой по `meta.phase` и `C` — процент
 использованного хранилища.
 
 График **Поставка событий: heartbeat retry-worker** читает

--- a/functions/lead-intake/src/observability/__tests__/ydb.test.ts
+++ b/functions/lead-intake/src/observability/__tests__/ydb.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { channel } from 'node:diagnostics_channel';
+import { channel, tracingChannel } from 'node:diagnostics_channel';
 import test from 'node:test';
 
 import { observeYdbOperation, prepareAndObserveYdbOperation } from '../ydb';
@@ -12,6 +12,8 @@ interface LogRecord extends JsonObject {
   retry_attempts?: number;
   error_code?: string;
 }
+
+type TestPhase = 'query.execute' | 'query.session.acquire' | 'query.session.create';
 
 function memoryLogger(): LoggerLike & { records: LogRecord[] } {
   const records: LogRecord[] = [];
@@ -37,6 +39,32 @@ function abortError(): Error {
   error.name = 'AbortError';
 
   return error;
+}
+
+async function tracePhase<T>(phase: TestPhase, callback: () => Promise<T>): Promise<T> {
+  let result: T | undefined;
+  await Promise.resolve(
+    tracingChannel(`tracing:ydb:${phase}`).tracePromise(async () => {
+      result = await callback();
+    }, {}),
+  );
+
+  return result as T;
+}
+
+async function withSlowThreshold<T>(value: string, callback: () => Promise<T>): Promise<T> {
+  const original = process.env.YDB_SLOW_OPERATION_MS;
+  process.env.YDB_SLOW_OPERATION_MS = value;
+
+  try {
+    return await callback();
+  } finally {
+    if (original === undefined) {
+      delete process.env.YDB_SLOW_OPERATION_MS;
+    } else {
+      process.env.YDB_SLOW_OPERATION_MS = original;
+    }
+  }
 }
 
 test('records YDB latency and retry attempts', async () => {
@@ -158,6 +186,99 @@ test('excludes client preparation from operation latency', async () => {
     assert.equal(recordByEvent(logger.records, 'ydb_operation_completed').duration_ms, 50);
     assert.equal(
       logger.records.some(record => record.event === 'ydb_slow_operation'),
+      false,
+    );
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
+test('records query and session phase durations without logging SQL text', async () => {
+  const logger = memoryLogger();
+  const originalNow = Date.now;
+  let now = 1_000;
+  Date.now = () => now;
+
+  try {
+    await observeYdbOperation('list_telegram_candidates', logger, async () => {
+      await tracePhase('query.session.acquire', async () => {
+        await tracePhase('query.session.create', async () => {
+          now += 700;
+        });
+      });
+      await tracePhase('query.execute', async () => {
+        now += 80;
+      });
+    });
+
+    const completed = recordByEvent(logger.records, 'ydb_operation_completed');
+    assert.equal(completed.duration_ms, 780);
+    assert.equal(completed.query_execute_duration_ms, 80);
+    assert.equal(completed.query_execute_max_duration_ms, 80);
+    assert.equal(completed.session_acquire_duration_ms, 700);
+    assert.equal(completed.session_create_duration_ms, 700);
+    assert.equal(JSON.stringify(completed).includes('SELECT'), false);
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
+test('slow session creation is diagnostic and does not trigger the slow-query event', async () => {
+  const logger = memoryLogger();
+  const originalNow = Date.now;
+  let now = 1_000;
+  Date.now = () => now;
+
+  try {
+    await withSlowThreshold('1000', () =>
+      observeYdbOperation('list_telegram_candidates', logger, async () => {
+        await tracePhase('query.session.acquire', async () => {
+          await tracePhase('query.session.create', async () => {
+            now += 7_600;
+          });
+        });
+        await tracePhase('query.execute', async () => {
+          now += 40;
+        });
+      }),
+    );
+
+    const diagnostic = recordByEvent(logger.records, 'ydb_slow_session_phase');
+    assert.equal(diagnostic.phase, 'session_create');
+    assert.equal(diagnostic.duration_ms, 7_600);
+    assert.equal(
+      logger.records.some(record => record.event === 'ydb_slow_operation'),
+      false,
+    );
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
+test('slow ExecuteQuery triggers the existing paging event with query-only latency', async () => {
+  const logger = memoryLogger();
+  const originalNow = Date.now;
+  let now = 1_000;
+  Date.now = () => now;
+
+  try {
+    await withSlowThreshold('1000', () =>
+      observeYdbOperation('list_telegram_candidates', logger, async () => {
+        await tracePhase('query.session.acquire', async () => {
+          now += 60;
+        });
+        await tracePhase('query.execute', async () => {
+          now += 1_500;
+        });
+      }),
+    );
+
+    const slowQuery = recordByEvent(logger.records, 'ydb_slow_operation');
+    assert.equal(slowQuery.phase, 'query_execute');
+    assert.equal(slowQuery.duration_ms, 1_500);
+    assert.equal(slowQuery.total_duration_ms, 1_560);
+    assert.equal(
+      logger.records.some(record => record.event === 'ydb_slow_session_phase'),
       false,
     );
   } finally {

--- a/functions/lead-intake/src/observability/ydb.ts
+++ b/functions/lead-intake/src/observability/ydb.ts
@@ -1,5 +1,5 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
-import { channel } from 'node:diagnostics_channel';
+import { channel, tracingChannel } from 'node:diagnostics_channel';
 
 import { safeErrorFields } from './errors';
 import { slowOperationMs } from '../ydb/config';
@@ -8,6 +8,21 @@ import type { JsonObject, LoggerLike } from '../types';
 
 interface OperationState {
   retries: number;
+  phases: Record<YdbPhase, PhaseAggregate>;
+}
+
+type YdbPhase = 'query_execute' | 'session_acquire' | 'session_create';
+
+interface PhaseAggregate {
+  attempts: number;
+  maxDurationMs: number;
+  totalDurationMs: number;
+}
+
+interface PhaseTrace {
+  operation: OperationState;
+  phase: YdbPhase;
+  startedAt: number;
 }
 
 interface ObserveYdbOperationOptions {
@@ -15,9 +30,60 @@ interface ObserveYdbOperationOptions {
 }
 
 const operationStorage = new AsyncLocalStorage<OperationState>();
+const phaseTraces = new WeakMap<object, PhaseTrace>();
 let subscribed = false;
 
-function subscribeToRetries(): void {
+function emptyPhaseAggregate(): PhaseAggregate {
+  return { attempts: 0, maxDurationMs: 0, totalDurationMs: 0 };
+}
+
+function createOperationState(): OperationState {
+  return {
+    retries: 0,
+    phases: {
+      query_execute: emptyPhaseAggregate(),
+      session_acquire: emptyPhaseAggregate(),
+      session_create: emptyPhaseAggregate(),
+    },
+  };
+}
+
+function isTraceContext(message: unknown): message is object {
+  return typeof message === 'object' && message !== null;
+}
+
+function subscribeToPhase(channelName: string, phase: YdbPhase): void {
+  tracingChannel(channelName).subscribe({
+    start(message) {
+      const operation = operationStorage.getStore();
+      if (operation && isTraceContext(message)) {
+        phaseTraces.set(message, { operation, phase, startedAt: Date.now() });
+      }
+    },
+    asyncStart(message) {
+      if (!isTraceContext(message)) {
+        return;
+      }
+
+      const trace = phaseTraces.get(message);
+      if (!trace) {
+        return;
+      }
+
+      const durationMs = Math.max(0, Date.now() - trace.startedAt);
+      const aggregate = trace.operation.phases[trace.phase];
+      aggregate.attempts += 1;
+      aggregate.totalDurationMs += durationMs;
+      aggregate.maxDurationMs = Math.max(aggregate.maxDurationMs, durationMs);
+      phaseTraces.delete(message);
+    },
+    end() {},
+    asyncEnd() {},
+    error() {},
+  });
+}
+
+function subscribeToDiagnostics(): void {
   if (subscribed) {
     return;
   }
@@ -31,7 +97,38 @@ function subscribeToRetries(): void {
       operation.retries += 1;
     }
   });
+  subscribeToPhase('tracing:ydb:query.execute', 'query_execute');
+  subscribeToPhase('tracing:ydb:query.session.acquire', 'session_acquire');
+  subscribeToPhase('tracing:ydb:query.session.create', 'session_create');
   subscribed = true;
+}
+
+function phaseFields(operation: OperationState): JsonObject {
+  return {
+    query_execute_attempts: operation.phases.query_execute.attempts,
+    query_execute_duration_ms: operation.phases.query_execute.totalDurationMs,
+    query_execute_max_duration_ms: operation.phases.query_execute.maxDurationMs,
+    session_acquire_attempts: operation.phases.session_acquire.attempts,
+    session_acquire_duration_ms: operation.phases.session_acquire.totalDurationMs,
+    session_acquire_max_duration_ms: operation.phases.session_acquire.maxDurationMs,
+    session_create_attempts: operation.phases.session_create.attempts,
+    session_create_duration_ms: operation.phases.session_create.totalDurationMs,
+    session_create_max_duration_ms: operation.phases.session_create.maxDurationMs,
+  };
+}
+
+function slowSessionPhase(operation: OperationState): { durationMs: number; phase: YdbPhase } | undefined {
+  const createDurationMs = operation.phases.session_create.maxDurationMs;
+  if (createDurationMs >= slowOperationMs()) {
+    return { durationMs: createDurationMs, phase: 'session_create' };
+  }
+
+  const acquireDurationMs = operation.phases.session_acquire.maxDurationMs;
+  if (acquireDurationMs >= slowOperationMs()) {
+    return { durationMs: acquireDurationMs, phase: 'session_acquire' };
+  }
+
+  return undefined;
 }
 
 function isAbortError(error: unknown): boolean {
@@ -52,10 +149,10 @@ export async function observeYdbOperation<T>(
   callback: () => Promise<T>,
   options: ObserveYdbOperationOptions = {},
 ): Promise<T> {
-  subscribeToRetries();
+  subscribeToDiagnostics();
 
   const startedAt = Date.now();
-  const operation = { retries: 0 };
+  const operation = createOperationState();
 
   try {
     const result = await operationStorage.run(operation, async () => {
@@ -78,6 +175,7 @@ export async function observeYdbOperation<T>(
       operation: operationName,
       duration_ms: durationMs,
       retry_attempts: operation.retries,
+      ...phaseFields(operation),
     });
 
     if (operation.retries > 0) {
@@ -88,11 +186,26 @@ export async function observeYdbOperation<T>(
       });
     }
 
-    if (durationMs >= slowOperationMs()) {
+    const queryDurationMs = operation.phases.query_execute.maxDurationMs;
+    if (queryDurationMs >= slowOperationMs()) {
       writeLog(logger, 'warn', {
         event: 'ydb_slow_operation',
         operation: operationName,
-        duration_ms: durationMs,
+        phase: 'query_execute',
+        duration_ms: queryDurationMs,
+        total_duration_ms: durationMs,
+      });
+    }
+
+    const sessionPhase = slowSessionPhase(operation);
+    if (sessionPhase) {
+      writeLog(logger, 'warn', {
+        event: 'ydb_slow_session_phase',
+        operation: operationName,
+        phase: sessionPhase.phase,
+        duration_ms: sessionPhase.durationMs,
+        total_duration_ms: durationMs,
+        ...phaseFields(operation),
       });
     }
 
@@ -103,6 +216,7 @@ export async function observeYdbOperation<T>(
       operation: operationName,
       duration_ms: Date.now() - startedAt,
       retry_attempts: operation.retries,
+      ...phaseFields(operation),
       ...safeErrorFields(error, { fallbackCode: 'ydb_error' }),
     });
     throw error;
@@ -122,7 +236,10 @@ export async function prepareAndObserveYdbOperation<TPrepared, TResult>(
 }
 
 export const _private = {
+  createOperationState,
   isAbortError,
-  subscribeToRetries,
+  phaseFields,
+  slowSessionPhase,
+  subscribeToDiagnostics,
   writeLog,
 };

--- a/knowledge-base/dashboards.md
+++ b/knowledge-base/dashboards.md
@@ -1,7 +1,7 @@
 ---
 type: dashboard
 title: ZvenFit production monitoring
-updated: 2026-08-16
+updated: 2026-08-17
 ---
 
 # Production monitoring dashboard
@@ -14,6 +14,8 @@ updated: 2026-08-16
   production application logs. The same canonical URLs are tracked in the
   monitoring runbook.
 - Empty event graphs are normal while the corresponding alert is green.
+- Slow YDB SQL pages only from `query_execute`; session acquire/create spikes
+  use a separate diagnostic graph and do not page.
 - Refresh interval: one minute.
 - Layout grid: 36 columns. Paired charts use 18 columns each; when a section has
   an unpaired final chart, it spans all 36 columns so the section ends without

--- a/scripts/__tests__/monitoring-config.test.cjs
+++ b/scripts/__tests__/monitoring-config.test.cjs
@@ -311,7 +311,6 @@ test('slow YDB session phases are diagnostic and never page', () => {
     'meta.environment',
     'meta.service',
     'meta.phase',
-    'resource_id',
   ]);
   assert.equal(metric.synthetic, false);
   assert.equal(config.alerts.some(item => item.metricId === metric.id), false);
@@ -320,6 +319,15 @@ test('slow YDB session phases are diagnostic and never page', () => {
   assert.match(chart.query, /name=\"zvenfit_ydb_slow_session_phases_5m\"/);
   assert.deepEqual(chart.decomposeBy, ['meta.phase']);
   assert.equal(chart.pagingAlert, false);
+});
+
+test('log metrics stay within the Monium four-label grouping limit', () => {
+  for (const metric of config.logMetrics) {
+    assert.ok(
+      metric.grouping.length <= 4,
+      `${metric.id} has ${metric.grouping.length} grouping labels; Monium allows at most 4`,
+    );
+  }
 });
 
 test('YDB storage alert uses live database metrics and 70/85 percent thresholds', () => {

--- a/scripts/__tests__/monitoring-config.test.cjs
+++ b/scripts/__tests__/monitoring-config.test.cjs
@@ -68,7 +68,7 @@ test('native dashboard JSON is restorable and matches critical desired-state inv
   });
   assert.equal(dashboardExport.title, 'ZvenFit · production');
   assert.equal(dashboardExport.name, 'zvenfit-production-monitoring');
-  assert.equal(dashboardExport.widgets.length, 24);
+  assert.equal(dashboardExport.widgets.length, 25);
 
   const quickAccessWidget = dashboardExport.widgets.find(
     widget => widget.widget === 'text' && widget.text?.text?.includes('Быстрый доступ к логам'),
@@ -87,7 +87,7 @@ test('native dashboard JSON is restorable and matches critical desired-state inv
   assert.match(alertList.alertList.selectors, /environment = "production"/);
 
   const chartTitles = dashboardExport.widgets
-    .filter(widget => widget.widget === 'multiSourceChart')
+    .filter(widget => widget.multiSourceChart)
     .map(widget => widget.multiSourceChart.title);
   assert.equal(
     chartTitles.some(title => title.startsWith('ZvenFit')),
@@ -95,15 +95,22 @@ test('native dashboard JSON is restorable and matches critical desired-state inv
   );
   assert.ok(chartTitles.includes('Cloud Functions: длительность p95'));
   assert.ok(chartTitles.includes('Поставка событий: heartbeat retry-worker'));
+  assert.ok(chartTitles.includes('YDB: медленные фазы сессий'));
 
   for (const title of [
     'Cloud Functions: длительность p95',
     'Поставка событий: heartbeat retry-worker',
+    'YDB: медленные фазы сессий',
   ]) {
     const widget = dashboardExport.widgets.find(item => item.multiSourceChart?.title === title);
     assert.deepEqual(widget.position, {
       x: '0',
-      y: title === 'Cloud Functions: длительность p95' ? '64' : '90',
+      y:
+        title === 'Cloud Functions: длительность p95'
+          ? '64'
+          : title === 'Поставка событий: heartbeat retry-worker'
+            ? '90'
+            : '98',
       w: '36',
       h: '8',
     });

--- a/scripts/__tests__/monitoring-config.test.cjs
+++ b/scripts/__tests__/monitoring-config.test.cjs
@@ -301,6 +301,27 @@ test('slow YDB alert warns on one event and alarms on three events in ten minute
   assert.equal(alert.delay, '3m');
 });
 
+test('slow YDB session phases are diagnostic and never page', () => {
+  const metric = config.logMetrics.find(item => item.id === 'zvenfit_ydb_slow_session_phases_5m');
+  const chart = config.dashboard.ydbSessionPhases;
+
+  assert.deepEqual(metric.events, ['ydb_slow_session_phase']);
+  assert.deepEqual(metric.grouping, [
+    'meta.application',
+    'meta.environment',
+    'meta.service',
+    'meta.phase',
+    'resource_id',
+  ]);
+  assert.equal(metric.synthetic, false);
+  assert.equal(config.alerts.some(item => item.metricId === metric.id), false);
+  assert.equal(chart.source, metric.id);
+  assert.match(chart.query, /service=\"logging_aggregates\"/);
+  assert.match(chart.query, /name=\"zvenfit_ydb_slow_session_phases_5m\"/);
+  assert.deepEqual(chart.decomposeBy, ['meta.phase']);
+  assert.equal(chart.pagingAlert, false);
+});
+
 test('YDB storage alert uses live database metrics and 70/85 percent thresholds', () => {
   const alert = config.alerts.find(item => item.id === 'zvenfit_ydb_storage_usage');
   const queryText = alert.queries.map(query => query.query).join('\n');

--- a/scripts/__tests__/monitoring-drift.test.cjs
+++ b/scripts/__tests__/monitoring-drift.test.cjs
@@ -18,7 +18,7 @@ const ROOT = path.resolve(__dirname, '../..');
 test('normalizes the desired monitoring resources into a stable read-only contract', () => {
   const normalized = normalizeMonitoringState(config);
 
-  assert.equal(normalized.logMetrics.length, 12);
+  assert.equal(normalized.logMetrics.length, 13);
   assert.equal(normalized.alerts.length, 16);
   assert.equal(normalized.notificationChannels.length, 2);
   assert.equal(normalized.dashboard.runtimeErrors.title, 'Cloud Functions: ошибки');

--- a/scripts/monitoring.config.json
+++ b/scripts/monitoring.config.json
@@ -210,7 +210,7 @@
       "filters": { "meta.service": "zvenfit-lead-intake", "resource_id": "*" },
       "aggregation": "count",
       "window": "5m",
-      "grouping": ["meta.application", "meta.environment", "meta.service", "meta.phase", "resource_id"],
+      "grouping": ["meta.application", "meta.environment", "meta.service", "meta.phase"],
       "synthetic": false
     },
     {

--- a/scripts/monitoring.config.json
+++ b/scripts/monitoring.config.json
@@ -112,6 +112,18 @@
         "heightRows": 8
       }
     },
+    "ydbSessionPhases": {
+      "title": "YDB: медленные фазы сессий",
+      "source": "zvenfit_ydb_slow_session_phases_5m",
+      "query": "series_sum({project=\"folder__b1ge1e4iopttj79hfdfm\", cluster=\"default\", service=\"logging_aggregates\", name=\"zvenfit_ydb_slow_session_phases_5m\", meta.application=\"zvenfit-frontend\", meta.environment=\"production\", meta.service=\"zvenfit-lead-intake\"})",
+      "visualization": "chart",
+      "decomposeBy": ["meta.phase"],
+      "pagingAlert": false,
+      "layout": {
+        "widthColumns": 36,
+        "heightRows": 8
+      }
+    },
     "trafficWidgets": [
       "Cloud CDN: запросы",
       "Cloud CDN: HTTP-статусы",
@@ -190,6 +202,16 @@
       "aggregation": "count",
       "window": "5m",
       "grouping": ["meta.application", "meta.environment", "meta.service", "resource_id"]
+    },
+    {
+      "id": "zvenfit_ydb_slow_session_phases_5m",
+      "displayName": "ZvenFit · YDB: медленные фазы сессий",
+      "events": ["ydb_slow_session_phase"],
+      "filters": { "meta.service": "zvenfit-lead-intake", "resource_id": "*" },
+      "aggregation": "count",
+      "window": "5m",
+      "grouping": ["meta.application", "meta.environment", "meta.service", "meta.phase", "resource_id"],
+      "synthetic": false
     },
     {
       "id": "zvenfit_rate_limit_errors_5m",

--- a/scripts/monitoring.dashboard.json
+++ b/scripts/monitoring.dashboard.json
@@ -1808,6 +1808,71 @@
         }
       },
       "widget": "multiSourceChart"
+    },
+    {
+      "position": {
+        "x": "0",
+        "y": "98",
+        "w": "36",
+        "h": "8"
+      },
+      "multiSourceChart": {
+        "id": "9765ee12-3dcd-49d3-bea9-7c1537bfc7e0",
+        "dataSources": [
+          {
+            "id": "5c55bf77-ca54-4b41-9da1-9a9e088026bd",
+            "type": "monitoring",
+            "downsampling": {
+              "gridAggregation": "GRID_AGGREGATION_UNSPECIFIED",
+              "gapFilling": "GAP_FILLING_UNSPECIFIED"
+            }
+          }
+        ],
+        "targets": [
+          {
+            "query": "{project=\"folder__b1ge1e4iopttj79hfdfm\", cluster=\"default\", service=\"logging_aggregates\", name=\"zvenfit_ydb_slow_session_phases_5m\", meta.application=\"zvenfit-frontend\", meta.environment=\"production\", meta.service=\"zvenfit-lead-intake\"}",
+            "hidden": false,
+            "name": "A",
+            "textMode": true,
+            "type": "monitoring",
+            "dataSourceId": "5c55bf77-ca54-4b41-9da1-9a9e088026bd",
+            "growDown": false
+          }
+        ],
+        "seriesOverrides": [],
+        "visualizationSettings": {
+          "type": "VISUALIZATION_TYPE_UNSPECIFIED",
+          "interpolate": "INTERPOLATE_UNSPECIFIED",
+          "yaxisSettings": {
+            "left": {
+              "type": "YAXIS_TYPE_LINEAR"
+            },
+            "right": {
+              "type": "YAXIS_TYPE_LINEAR"
+            }
+          },
+          "colorSchemeSettings": {
+            "automatic": {}
+          }
+        },
+        "thresholds": {
+          "items": [
+            {
+              "color": "#92db00",
+              "id": "753a491f-dc05-470f-b64f-1b8affe42022"
+            }
+          ],
+          "showMode": "CONSTANT_LINE"
+        },
+        "title": "YDB: медленные фазы сессий",
+        "legendSettings": {
+          "position": "POSITION_BOTTOM",
+          "list": {
+            "columnsCount": 0
+          },
+          "truncate": "TRUNCATE_END"
+        }
+      }
     }
   ],
   "links": [],


### PR DESCRIPTION
## Что меняется
- разделяем latency YDB на query.execute, session.acquire и session.create
- сохраняем paging WARN только для медленного ExecuteQuery
- пишем отдельный диагностический WARN для медленных session-фаз
- добавляем desired state log-метрики и dashboard-разреза по phase

## Почему
Последний флап мог быть вызван ожиданием/созданием SDK-сессии, хотя алерт выглядел как медленный запрос. После выкладки это различие будет видно непосредственно в логах и на графике.

## Проверки
- npm test --prefix functions/lead-intake
- npm run test:monitoring
- npm run lint:public
- npm run build
- git diff --check