### PR TITLE
fix: retry transient YDB initialization failures

### DIFF
--- a/functions/lead-intake/src/ydb/__tests__/client.test.ts
+++ b/functions/lead-intake/src/ydb/__tests__/client.test.ts
@@ -1,0 +1,129 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { _private } from '../client';
+
+interface FakeDriver {
+  close(): void;
+  ready(signal: AbortSignal): Promise<void>;
+}
+
+function transientError(): Error & { code: string } {
+  return Object.assign(new Error('/Ydb.Discovery.V1.DiscoveryService/ListEndpoints DEADLINE_EXCEEDED'), {
+    code: 'DEADLINE_EXCEEDED',
+  });
+}
+
+test('recreates the YDB driver after a transient discovery failure', async () => {
+  let created = 0;
+  let closed = 0;
+  const delays: number[] = [];
+  const recoveredDriver: FakeDriver = {
+    close() {
+      closed += 1;
+    },
+    async ready() {},
+  };
+
+  const result = await _private.initializeDriver(
+    () => {
+      created += 1;
+
+      if (created === 1) {
+        return {
+          close() {
+            closed += 1;
+          },
+          async ready() {
+            throw transientError();
+          },
+        };
+      }
+
+      return recoveredDriver;
+    },
+    5000,
+    {
+      delay: async attempt => {
+        delays.push(attempt);
+      },
+    },
+  );
+
+  assert.equal(result, recoveredDriver);
+  assert.equal(created, 2);
+  assert.equal(closed, 1);
+  assert.deepEqual(delays, [1]);
+});
+
+test('does not retry a permanent YDB initialization failure', async () => {
+  let created = 0;
+  let closed = 0;
+  const error = Object.assign(new Error('Permission denied'), { code: 'PERMISSION_DENIED' });
+
+  await assert.rejects(
+    _private.initializeDriver(
+      () => {
+        created += 1;
+
+        return {
+          close() {
+            closed += 1;
+          },
+          async ready() {
+            throw error;
+          },
+        };
+      },
+      5000,
+      { delay: async () => assert.fail('permanent failures must not be delayed or retried') },
+    ),
+    error,
+  );
+
+  assert.equal(created, 1);
+  assert.equal(closed, 1);
+});
+
+test('stops after one retry when YDB discovery remains unavailable', async () => {
+  let created = 0;
+  let closed = 0;
+
+  await assert.rejects(
+    _private.initializeDriver(
+      () => {
+        created += 1;
+
+        return {
+          close() {
+            closed += 1;
+          },
+          async ready() {
+            throw transientError();
+          },
+        };
+      },
+      5000,
+      { delay: async () => {} },
+    ),
+    { code: 'DEADLINE_EXCEEDED' },
+  );
+
+  assert.equal(created, 2);
+  assert.equal(closed, 2);
+});
+
+test('recognizes transient gRPC codes in nested causes', () => {
+  assert.equal(
+    _private.isTransientInitializationError(
+      Object.assign(new Error('driver init failed'), {
+        cause: Object.assign(new Error('transport failed'), { code: 14 }),
+      }),
+    ),
+    true,
+  );
+  assert.equal(
+    _private.isTransientInitializationError(Object.assign(new Error('invalid database'), { code: 3 })),
+    false,
+  );
+});

--- a/functions/lead-intake/src/ydb/client.ts
+++ b/functions/lead-intake/src/ydb/client.ts
@@ -3,6 +3,84 @@ import { normalizeConnectionString, queryTimeoutMs, sessionPoolSize } from './co
 import type { YdbClient, YdbSql, YdbValueConstructor } from '../types';
 import type { CredentialsProvider } from '@ydbjs/auth' with { 'resolution-mode': 'import' };
 
+interface ReadyDriver {
+  close(): void;
+  ready(signal: AbortSignal): Promise<void>;
+}
+
+interface DriverInitializationOptions {
+  attempts?: number;
+  delay?: (attempt: number) => Promise<void>;
+}
+
+const DEFAULT_INITIALIZATION_ATTEMPTS = 2;
+const INITIALIZATION_RETRY_DELAY_MS = 100;
+const TRANSIENT_GRPC_CODES = new Set([4, 8, 10, 13, 14]);
+const TRANSIENT_ERROR_PATTERN =
+  /ABORTED|DEADLINE_EXCEEDED|EAI_AGAIN|ECONNRESET|ECONNREFUSED|ETIMEDOUT|INTERNAL|RESOURCE_EXHAUSTED|TIMEOUT|UNAVAILABLE/i;
+
+function errorChain(error: unknown): unknown[] {
+  const chain: unknown[] = [];
+  const visited = new Set<unknown>();
+  let current = error;
+
+  while (current && typeof current === 'object' && !visited.has(current) && chain.length < 4) {
+    chain.push(current);
+    visited.add(current);
+    current = (current as Record<string, unknown>).cause;
+  }
+
+  return chain;
+}
+
+function isTransientInitializationError(error: unknown): boolean {
+  return errorChain(error).some(item => {
+    const record = item as Record<string, unknown>;
+    if (typeof record.code === 'number' && TRANSIENT_GRPC_CODES.has(record.code)) {
+      return true;
+    }
+
+    const description = [record.name, record.code, record.message, record.details]
+      .filter(value => typeof value === 'string')
+      .join(' ');
+
+    return TRANSIENT_ERROR_PATTERN.test(description);
+  });
+}
+
+function retryDelay(attempt: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, INITIALIZATION_RETRY_DELAY_MS * attempt));
+}
+
+async function initializeDriver<T extends ReadyDriver>(
+  createDriver: () => T,
+  timeoutMs: number,
+  options: DriverInitializationOptions = {},
+): Promise<T> {
+  const attempts = Math.max(1, options.attempts ?? DEFAULT_INITIALIZATION_ATTEMPTS);
+  const delay = options.delay ?? retryDelay;
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const driver = createDriver();
+
+    try {
+      await driver.ready(AbortSignal.timeout(timeoutMs));
+
+      return driver;
+    } catch (error) {
+      driver.close();
+
+      if (attempt === attempts || !isTransientInitializationError(error)) {
+        throw error;
+      }
+
+      await delay(attempt);
+    }
+  }
+
+  throw new Error('ydb_driver_initialization_failed');
+}
+
 export async function createYdbClient(): Promise<YdbClient> {
   const [{ Driver }, { query }, { MetadataCredentialsProvider }, { Timestamp, Uint32 }] = await Promise.all([
     import('@ydbjs/core'),
@@ -18,8 +96,7 @@ export async function createYdbClient(): Promise<YdbClient> {
     credentialsProvider = new EnvironCredentialsProvider(connectionString);
   }
 
-  const driver = new Driver(connectionString, { credentialsProvider });
-  await driver.ready(AbortSignal.timeout(queryTimeoutMs()));
+  const driver = await initializeDriver(() => new Driver(connectionString, { credentialsProvider }), queryTimeoutMs());
 
   const sql = query(driver, {
     poolOptions: { maxSize: sessionPoolSize() },
@@ -38,3 +115,5 @@ export async function createYdbClient(): Promise<YdbClient> {
     },
   };
 }
+
+export const _private = { errorChain, initializeDriver, isTransientInitializationError };


### PR DESCRIPTION
## Summary
- retry YDB driver initialization once for transient gRPC and network failures
- close a failed driver before recreating it
- preserve failures for permanent errors and sustained outages

## Verification
- npm test (functions/lead-intake)
- npm run lint:public
- git diff --check