### PR TITLE
fix: выровнять навигацию клубной карты

### DIFF
--- a/public/css/klubnaya-karta.v1.css
+++ b/public/css/klubnaya-karta.v1.css
@@ -45,6 +45,20 @@ html[data-zvenfit-page="club-card"] .club-card-logo img {
   height: 29px;
 }
 
+html[data-zvenfit-page="club-card"] .menu_grid-2 > .link-block-page1 {
+  place-self: center start;
+}
+
+html[data-zvenfit-page="club-card"] .menu_grid-2 > .link-block-page2,
+html[data-zvenfit-page="club-card"] .menu_grid-2 > .club-card-logo,
+html[data-zvenfit-page="club-card"] .menu_grid-2 > .link-block-page3 {
+  place-self: center;
+}
+
+html[data-zvenfit-page="club-card"] .menu_grid-2 > .link-block-page4 {
+  place-self: center end;
+}
+
 html[data-zvenfit-page="club-card"] .photo_page.club-card-hero {
   min-height: 420px;
   height: min(70vh, 760px);


### PR DESCRIPTION
## Что исправлено

- восстановлено симметричное выравнивание пунктов desktop-шапки клубной карты;
- логотип явно закреплён по центру;
- правила ограничены только страницей `data-zvenfit-page=club-card`;
- hero и остальные страницы не изменялись.

## Проверка

- `npm run build`;
- `npm run test:build`;
- `npm run lint:public`;
- визуальная проверка 1920, 1440, 1024, 991, 768, 390 и 320 px;
- мобильный сценарий: открыть меню → перейти по якорю → повторно открыть одним нажатием.