### PR TITLE
fix: сбрасывать кэш CSS клубной карты

### DIFF
--- a/scripts/build-static.cjs
+++ b/scripts/build-static.cjs
@@ -73,6 +73,7 @@ const CACHE_BUST_SCRIPTS = [
   'maps-config.js',
   'yandex-map.js',
 ];
+const CACHE_BUST_STYLES = ['klubnaya-karta.v1.css'];
 
 const MAP_IFRAME_RE = /<div class="code-embed-4 w-embed w-iframe"><iframe[^>]*map-widget[^>]*>\s*<\/iframe><\/div>/g;
 
@@ -251,6 +252,11 @@ function bustAssetUrls(html, assetVersion) {
   let nextHtml = html;
   for (const scriptName of CACHE_BUST_SCRIPTS) {
     const pattern = new RegExp(`(/js/${scriptName})(?:\\?v=[^"']*)?`, 'g');
+    nextHtml = nextHtml.replace(pattern, `$1?v=${assetVersion}`);
+  }
+
+  for (const stylesheetName of CACHE_BUST_STYLES) {
+    const pattern = new RegExp(`(/css/${escapeRegExp(stylesheetName)})(?:\\?v=[^"']*)?`, 'g');
     nextHtml = nextHtml.replace(pattern, `$1?v=${assetVersion}`);
   }
 

--- a/scripts/check-build.cjs
+++ b/scripts/check-build.cjs
@@ -110,8 +110,8 @@ if (relativeHtmlLink) {
 if (!clubCardHtml.includes('<link rel="canonical" href="https://zvenfit.ru/klubnaya-karta/">')) {
   throw new Error('check-build: club card page canonical URL is missing');
 }
-if (!clubCardHtml.includes('/css/klubnaya-karta.v1.css')) {
-  throw new Error('check-build: club card page-scoped stylesheet is missing');
+if (!clubCardHtml.includes('/css/klubnaya-karta.v1.css?v=')) {
+  throw new Error('check-build: club card page-scoped stylesheet is missing its cache-busting version');
 }
 if (!clubCardHtml.includes('data-map-set="chekhova"') || !clubCardHtml.includes('/js/yandex-map.js?v=')) {
   throw new Error('check-build: club card page map was not converted to the shared runtime map');


### PR DESCRIPTION
## Что исправлено

- клубный CSS подключён к существующему механизму `ASSET_VERSION`;
- production HTML теперь получает ссылку вида `/css/klubnaya-karta.v1.css?v=<github.run_number>`;
- добавлена build-проверка обязательного cache-busting параметра.

## Почему без переименования в v2

`ASSET_VERSION` уже автоматически меняется на каждом deploy. CDN учитывает query-параметр, поэтому подключение stylesheet к этому механизму решает текущий кэш и предотвращает повторение проблемы при следующих CSS-изменениях.

## Проверка

- custom `ASSET_VERSION=cache-check-6b30e85 npm run build`;
- `npm run test:build`;
- `npm run lint:public`;
- CDN query cache key проверен: новая версия возвращается с актуальным ETag и `cache-status: MISS`.